### PR TITLE
Add a deploy command & improve expression translation

### DIFF
--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -1,9 +1,9 @@
+import subprocess
 from runpy import run_path
 from types import FunctionType
 
 import click
 import yaml
-import subprocess
 
 from solver import (
     Case,
@@ -83,7 +83,7 @@ def export(policy_file):
 
 @main.command()
 @click.argument("policy-file")
-@click.option('--sudo', '-s', is_flag=True)
+@click.option("--sudo", "-s", is_flag=True)
 def deploy(policy_file, sudo):
     click.echo("parsing policy...")
     module = run_path(policy_file, env)
@@ -97,7 +97,8 @@ def deploy(policy_file, sudo):
         args.insert(0, "sudo")
 
     subprocess.run(args, text=True, input=serialized, check=True)
-    click.echo(f"policy deployed as resource \"{policy.name}\"")
+    click.echo(f'policy deployed as resource "{policy.name}"')
+
 
 @main.command()
 @click.argument("policy-file")

--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -3,6 +3,7 @@ from types import FunctionType
 
 import click
 import yaml
+import subprocess
 
 from solver import (
     Case,
@@ -79,6 +80,19 @@ def export(policy_file):
     serialized = yaml.dump(obj)
     click.echo(serialized)
 
+
+@main.command()
+@click.argument("policy-file")
+def deploy(policy_file):
+    click.echo("parsing policy...")
+    module = run_path(policy_file, env)
+    policy = module["Teleport"].p
+    click.echo("translating policy...")
+    obj = policy.export()
+    serialized = yaml.dump(obj)
+    click.echo("deploying policy...")
+    subprocess.run(["tctl", "create", "-f", "-"], text=True, input=serialized, check=True)
+    click.echo(f"policy deployed as resource \"{policy.name}\"")
 
 @main.command()
 @click.argument("policy-file")

--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -83,7 +83,8 @@ def export(policy_file):
 
 @main.command()
 @click.argument("policy-file")
-def deploy(policy_file):
+@click.option('--sudo', '-s', is_flag=True)
+def deploy(policy_file, sudo):
     click.echo("parsing policy...")
     module = run_path(policy_file, env)
     policy = module["Teleport"].p
@@ -91,7 +92,11 @@ def deploy(policy_file):
     obj = policy.export()
     serialized = yaml.dump(obj)
     click.echo("deploying policy...")
-    subprocess.run(["tctl", "create", "-f", "-"], text=True, input=serialized, check=True)
+    args = ["tctl", "create", "-f", "-"]
+    if sudo:
+        args.insert(0, "sudo")
+
+    subprocess.run(args, text=True, input=serialized, check=True)
     click.echo(f"policy deployed as resource \"{policy.name}\"")
 
 @main.command()

--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -92,7 +92,7 @@ def deploy(policy_file, sudo):
     obj = policy.export()
     serialized = yaml.dump(obj)
     click.echo("deploying policy...")
-    args = ["tctl", "create", "-f", "-"]
+    args = ["tctl", "create", "-f"]
     if sudo:
         args.insert(0, "sudo")
 

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -18,15 +18,6 @@ class Teleport:
         ret, _ = self.p.check(Node((Node.login == "alice") & (User.name == "alice") & (Node.labels["env"] == "dev")))
         assert ret is True, "Alice can login with her user to any node"
 
-        # We can verify that a strong invariant holds:
-        # Unless a username is root, a user can not access a server as
-        # root. This creates a problem though, can we deny access as root
-        # altogether?
-        #ret, _ = self.p.check(Node((Node.login == "root") & (User.name != "root")))
-        #assert (
-        #    ret is False
-        #), "This role does not allow access as root unless a user name is root"
-
         # No one is permitted to login as mike
         ret, _ = self.p.query(Node((Node.login == "mike")))
         assert ret is False, "This role does not allow access as mike"

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -6,13 +6,13 @@ class Teleport:
             Node(((Node.login == User.name) & (User.name != "root")) | (User.traits["team"] == ("admins",))),
         ),
         deny=Rules(
-            Node((Node.login == "mike") | (Node.login == "jester")),
+            Node((Node.login == "mike") | (Node.login == "jester") | (Node.labels["env"] == "prod")),
         ),
     )
 
     def test_access(self):
         # Alice will be able to login to any machine as herself
-        ret, _ = self.p.check(Node((Node.login == "alice") & (User.name == "alice")))
+        ret, _ = self.p.check(Node((Node.login == "alice") & (User.name == "alice") & (Node.labels["env"] == "dev")))
         assert ret is True, "Alice can login with her user to any node"
 
         # We can verify that a strong invariant holds:

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -3,7 +3,7 @@ class Teleport:
         name="access",
         loud=False,
         allow=Rules(
-            Node((Node.login == User.name) & (User.name == "root")),
+            Node((Node.login == User.name) & (User.name != "root")),
         ),
         deny=Rules(
             Node((Node.login == "mike") | (Node.login == "jester")),

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -3,7 +3,7 @@ class Teleport:
         name="access",
         loud=False,
         allow=Rules(
-            Node((Node.login == User.name) & (User.name != "root")),
+            Node(((Node.login == User.name) & (User.name != "root")) | (User.traits["team"] == ("admins",))),
         ),
         deny=Rules(
             Node((Node.login == "mike") | (Node.login == "jester")),
@@ -19,10 +19,10 @@ class Teleport:
         # Unless a username is root, a user can not access a server as
         # root. This creates a problem though, can we deny access as root
         # altogether?
-        ret, _ = self.p.check(Node((Node.login == "root") & (User.name != "root")))
-        assert (
-            ret is False
-        ), "This role does not allow access as root unless a user name is root"
+        #ret, _ = self.p.check(Node((Node.login == "root") & (User.name != "root")))
+        #assert (
+        #    ret is False
+        #), "This role does not allow access as root unless a user name is root"
 
         # No one is permitted to login as mike
         ret, _ = self.p.query(Node((Node.login == "mike")))

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -3,10 +3,10 @@ class Teleport:
         name="access",
         loud=False,
         allow=Rules(
-            Node((Node.login == User.name)),
+            Node((Node.login == User.name) & (User.name == "root")),
         ),
         deny=Rules(
-            Node((Node.login == "mike")),
+            Node((Node.login == "mike") | (Node.login == "jester")),
         ),
     )
 
@@ -27,3 +27,7 @@ class Teleport:
         # No one is permitted to login as mike
         ret, _ = self.p.query(Node((Node.login == "mike")))
         assert ret is False, "This role does not allow access as mike"
+
+        # No one is permitted to login as jester
+        ret, _ = self.p.query(Node((Node.login == "jester")))
+        assert ret is False, "This role does not allow access as jester"

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -3,19 +3,30 @@ class Teleport:
         name="access",
         loud=False,
         allow=Rules(
-            Node(((Node.login == User.name) & (User.name != "root")) | (User.traits["team"] == ("admins",))),
+            Node(
+                ((Node.login == User.name) & (User.name != "root"))
+                | (User.traits["team"] == ("admins",))
+            ),
         ),
-        options=OptionsSet(
-            Options((Options.max_session_ttl < Duration.new(hours=10)))
-        ),
+        options=OptionsSet(Options((Options.max_session_ttl < Duration.new(hours=10)))),
         deny=Rules(
-            Node((Node.login == "mike") | (Node.login == "jester") | (Node.labels["env"] == "prod")),
+            Node(
+                (Node.login == "mike")
+                | (Node.login == "jester")
+                | (Node.labels["env"] == "prod")
+            ),
         ),
     )
 
     def test_access(self):
         # Alice will be able to login to any machine as herself
-        ret, _ = self.p.check(Node((Node.login == "alice") & (User.name == "alice") & (Node.labels["env"] == "dev")))
+        ret, _ = self.p.check(
+            Node(
+                (Node.login == "alice")
+                & (User.name == "alice")
+                & (Node.labels["env"] == "dev")
+            )
+        )
         assert ret is True, "Alice can login with her user to any node"
 
         # No one is permitted to login as mike

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -5,6 +5,9 @@ class Teleport:
         allow=Rules(
             Node(((Node.login == User.name) & (User.name != "root")) | (User.traits["team"] == ("admins",))),
         ),
+        options=OptionsSet(
+            Options((Options.max_session_ttl < Duration.new(hours=10)))
+        ),
         deny=Rules(
             Node((Node.login == "mike") | (Node.login == "jester") | (Node.labels["env"] == "prod")),
         ),

--- a/predicate/pyproject.toml
+++ b/predicate/pyproject.toml
@@ -31,6 +31,9 @@ source = "."
 extra-requirements = "types-requests"
 use-mypy = true
 
+[tool.isort]
+profile = "black"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -238,25 +238,15 @@ def t_expr(predicate):
         return f"{predicate.m.name}[{t_expr(predicate.key)}]"
     elif isinstance(predicate, ast.StringSetMapIndexEquals):
         return f"equals({predicate.E.m.name}[{t_expr(predicate.E.key)}], {t_expr(predicate.V.vals)})"
-    elif isinstance(predicate, ast.String):
+    elif isinstance(predicate, (ast.String, ast.Duration, ast.StringList, ast.StringEnum, ast.Bool, ast.Int)):
         return predicate.name
     elif isinstance(predicate, ast.StringLiteral):
         return f'"{predicate.V}"'
-    elif isinstance(predicate, ast.Duration):
-        return predicate.name
-    elif isinstance(predicate, ast.DurationLiteral):
-        return f"{predicate.V}"
     elif isinstance(predicate, str):
         return f'"{predicate}"'
     elif isinstance(predicate, tuple):
         return f"[{', '.join(t_expr(p) for p in predicate)}]"
-    elif isinstance(predicate, ast.Bool):
-        return f"{predicate.name}"
-    elif isinstance(predicate, ast.BoolLiteral):
-        return f"{predicate.V}"
-    elif isinstance(predicate, ast.Int):
-        return f"{predicate.name}"
-    elif isinstance(predicate, ast.IntLiteral):
+    elif isinstance(predicate, (ast.BoolLiteral, ast.IntLiteral, ast.DurationLiteral)):
         return f"{predicate.V}"
     elif isinstance(predicate, ast.Concat):
         return f"({t_expr(predicate.L)} + {t_expr(predicate.R)})"
@@ -268,9 +258,7 @@ def t_expr(predicate):
         return f"upper({t_expr(predicate.val)})"
     elif isinstance(predicate, ast.Lower):
         return f"lower({t_expr(predicate.val)})"
-    elif isinstance(predicate, ast.StringList):
-        return predicate.name
-    elif isinstance(predicate, ast.StringListContains):
+    elif isinstance(predicate, (ast.StringListContains, ast.IterableContains)):
         return f"contains({t_expr(predicate.E)}, {t_expr(predicate.V)})"
     elif isinstance(predicate, ast.StringListFirst):
         return f"first({t_expr(predicate.E)})"
@@ -278,24 +266,16 @@ def t_expr(predicate):
         return f"add({t_expr(predicate.E)}, {t_expr(predicate.V)})"
     elif isinstance(predicate, ast.StringListEquals):
         return f"equals({t_expr(predicate.E)}, {t_expr(predicate.V)})"
-    elif isinstance(predicate, ast.Replace):
+    elif isinstance(predicate, (ast.Replace, ast.StringListReplace)):
         return f"replace({t_expr(predicate.val)}, {t_expr(predicate.src)}, {t_expr(predicate.dst)})"
-    elif isinstance(predicate, ast.StringListReplace):
-        return f"replace({t_expr(predicate.E)}, {t_expr(predicate.S)}, {t_expr(predicate.D)})"
     elif isinstance(predicate, ast.RegexConstraint):
         return f"regex({t_expr(predicate.expr)})"
     elif isinstance(predicate, ast.RegexTuple):
         return f"[{', '.join(t_expr(p) for p in predicate.vals)}]"
-    elif isinstance(predicate, ast.Matches):
+    elif isinstance(predicate, (ast.Matches, ast.IterableMatches)):
         return f"matches({t_expr(predicate.E)}, {t_expr(predicate.V)})"
-    elif isinstance(predicate, ast.IterableMatches):
-        return f"matches({t_expr(predicate.E)}, {t_expr(predicate.V)})"
-    elif isinstance(predicate, ast.StringEnum):
-        return predicate.name
     elif isinstance(predicate, ast.StringListContainsRegex):
         return f"contains_regex({t_expr(predicate.E)}, {t_expr(predicate.V)})"
-    elif isinstance(predicate, ast.IterableContains):
-        return f"contains({t_expr(predicate.E)}, {t_expr(predicate.V)})"
     elif isinstance(predicate, ast.If):
         return f"if({t_expr(predicate.cond)}, {t_expr(predicate.on_true)}, {t_expr(predicate.on_false)})"
     elif isinstance(predicate, ast.Select):

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -219,6 +219,8 @@ def t_expr(predicate):
         return f"({t_expr(predicate.L)} && {t_expr(predicate.R)})"
     elif isinstance(predicate, ast.Not):
         return f"(!{t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.StringSetMapIndexEquals):
+        return f"contains({predicate.E.m.name}[\"{predicate.E.key}\"], {list(predicate.V.vals)})"
     elif isinstance(predicate, ast.String):
         return predicate.name
     elif isinstance(predicate, ast.StringLiteral):

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -258,6 +258,10 @@ def t_expr(predicate):
         return f'{predicate.name}'
     elif isinstance(predicate, ast.IntLiteral):
         return f'{predicate.V}'
+    elif isinstance(predicate, ast.Concat):
+        return f'({t_expr(predicate.L)} + {t_expr(predicate.R)})'
+    elif isinstance(predicate, ast.Split):
+        return f'{t_expr(predicate.val)}.split({t_expr(predicate.sep)})'
     else:
         raise Exception(f"unknown predicate type: {type(predicate)}")
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -236,9 +236,18 @@ def t_expr(predicate):
         return f"({t_expr(predicate.L)} > {t_expr(predicate.R)})"
     elif isinstance(predicate, ast.MapIndex):
         return f"{predicate.m.name}[{t_expr(predicate.key)}]"
-    elif isinstance(predicate, ast.StringSetMapIndexEquals):
-        return f"equals({predicate.E.m.name}[{t_expr(predicate.E.key)}], {t_expr(predicate.V.vals)})"
-    elif isinstance(predicate, (ast.String, ast.Duration, ast.StringList, ast.StringEnum, ast.Bool, ast.Int)):
+    elif isinstance(
+        predicate,
+        (
+            ast.String,
+            ast.Duration,
+            ast.StringList,
+            ast.StringEnum,
+            ast.Bool,
+            ast.Int,
+            ast.StringSetMap,
+        ),
+    ):
         return predicate.name
     elif isinstance(predicate, ast.StringLiteral):
         return f'"{predicate.V}"'
@@ -258,15 +267,20 @@ def t_expr(predicate):
         return f"upper({t_expr(predicate.val)})"
     elif isinstance(predicate, ast.Lower):
         return f"lower({t_expr(predicate.val)})"
-    elif isinstance(predicate, (ast.StringListContains, ast.IterableContains)):
+    elif isinstance(
+        predicate,
+        (ast.StringListContains, ast.IterableContains, ast.StringSetMapIndexContains),
+    ):
         return f"contains({t_expr(predicate.E)}, {t_expr(predicate.V)})"
     elif isinstance(predicate, ast.StringListFirst):
         return f"first({t_expr(predicate.E)})"
-    elif isinstance(predicate, ast.StringListAdd):
+    elif isinstance(predicate, (ast.StringListAdd, ast.StringSetMapIndexAdd)):
         return f"add({t_expr(predicate.E)}, {t_expr(predicate.V)})"
-    elif isinstance(predicate, ast.StringListEquals):
+    elif isinstance(predicate, (ast.StringListEquals, ast.StringSetMapIndexEquals)):
         return f"equals({t_expr(predicate.E)}, {t_expr(predicate.V)})"
-    elif isinstance(predicate, (ast.Replace, ast.StringListReplace)):
+    elif isinstance(
+        predicate, (ast.Replace, ast.StringListReplace, ast.StringSetMapIndexReplace)
+    ):
         return f"replace({t_expr(predicate.val)}, {t_expr(predicate.src)}, {t_expr(predicate.dst)})"
     elif isinstance(predicate, ast.RegexConstraint):
         return f"regex({t_expr(predicate.expr)})"
@@ -274,7 +288,9 @@ def t_expr(predicate):
         return f"[{', '.join(t_expr(p) for p in predicate.vals)}]"
     elif isinstance(predicate, (ast.Matches, ast.IterableMatches)):
         return f"matches({t_expr(predicate.E)}, {t_expr(predicate.V)})"
-    elif isinstance(predicate, ast.StringListContainsRegex):
+    elif isinstance(
+        predicate, (ast.StringListContainsRegex, ast.StringSetMapIndexContainsRegex)
+    ):
         return f"contains_regex({t_expr(predicate.E)}, {t_expr(predicate.V)})"
     elif isinstance(predicate, ast.If):
         return f"if({t_expr(predicate.cond)}, {t_expr(predicate.on_true)}, {t_expr(predicate.on_false)})"
@@ -284,6 +300,16 @@ def t_expr(predicate):
         return f"case({t_expr(predicate.when)}, {t_expr(predicate.then)})"
     elif isinstance(predicate, ast.Default):
         return f"default({t_expr(predicate.expr)})"
+    elif isinstance(predicate, ast.StringSetMapIndex):
+        return f"{predicate.m.name}[{t_expr(predicate.key)}]"
+    elif isinstance(predicate, ast.StringSetMapIndexLen):
+        return f"len({t_expr(predicate.E)})"
+    elif isinstance(predicate, ast.StringSetMapIndexFirst):
+        return f"first({t_expr(predicate.E)})"
+    elif isinstance(predicate, ast.StringSetMapAddValue):
+        return f"map_add({t_expr(predicate.m.name)}, {t_expr(predicate.K)}, {t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.StringSetMapRemoveKeys):
+        return f"map_remove({t_expr(predicate.m.name)}, {t_expr(predicate.K)})"
     else:
         raise Exception(f"unknown predicate type: {type(predicate)}")
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -251,17 +251,17 @@ def t_expr(predicate):
     elif isinstance(predicate, tuple):
         return f"[{', '.join(t_expr(p) for p in predicate)}]"
     elif isinstance(predicate, ast.Bool):
-        return f'{predicate.name}'
+        return f"{predicate.name}"
     elif isinstance(predicate, ast.BoolLiteral):
-        return f'{predicate.V}'
+        return f"{predicate.V}"
     elif isinstance(predicate, ast.Int):
-        return f'{predicate.name}'
+        return f"{predicate.name}"
     elif isinstance(predicate, ast.IntLiteral):
-        return f'{predicate.V}'
+        return f"{predicate.V}"
     elif isinstance(predicate, ast.Concat):
-        return f'({t_expr(predicate.L)} + {t_expr(predicate.R)})'
+        return f"({t_expr(predicate.L)} + {t_expr(predicate.R)})"
     elif isinstance(predicate, ast.Split):
-        return f'split({t_expr(predicate.val)}, {t_expr(predicate.sep)})'
+        return f"split({t_expr(predicate.val)}, {t_expr(predicate.sep)})"
     elif isinstance(predicate, ast.StringTuple):
         return f"[{', '.join(t_expr(p) for p in predicate.vals)}]"
     elif isinstance(predicate, ast.Upper):

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -219,12 +219,16 @@ def t_expr(predicate):
         return f"({t_expr(predicate.L)} && {t_expr(predicate.R)})"
     elif isinstance(predicate, ast.Not):
         return f"(!{t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.MapIndex):
+        return f"{predicate.m.name}[{t_expr(predicate.key)}]"
     elif isinstance(predicate, ast.StringSetMapIndexEquals):
         return f"contains({predicate.E.m.name}[\"{predicate.E.key}\"], {list(predicate.V.vals)})"
     elif isinstance(predicate, ast.String):
         return predicate.name
     elif isinstance(predicate, ast.StringLiteral):
         return f'"{predicate.V}"'
+    elif isinstance(predicate, str):
+        return f'"{predicate}"'
     else:
         raise Exception(f"unknown predicate type: {type(predicate)}")
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -226,10 +226,14 @@ def t_expr(predicate):
         return f"({t_expr(predicate.L)} || {t_expr(predicate.R)})"
     elif isinstance(predicate, ast.And):
         return f"({t_expr(predicate.L)} && {t_expr(predicate.R)})"
+    elif isinstance(predicate, ast.Xor):
+        return f"({t_expr(predicate.L)} ^ {t_expr(predicate.R)})"
     elif isinstance(predicate, ast.Not):
         return f"(!{t_expr(predicate.V)})"
     elif isinstance(predicate, ast.Lt):
         return f"({t_expr(predicate.L)} < {t_expr(predicate.R)})"
+    elif isinstance(predicate, ast.Gt):
+        return f"({t_expr(predicate.L)} > {t_expr(predicate.R)})"
     elif isinstance(predicate, ast.MapIndex):
         return f"{predicate.m.name}[{t_expr(predicate.key)}]"
     elif isinstance(predicate, ast.StringSetMapIndexEquals):
@@ -246,6 +250,14 @@ def t_expr(predicate):
         return f'"{predicate}"'
     elif isinstance(predicate, tuple):
         return f"[{', '.join(t_expr(p) for p in predicate)}]"
+    elif isinstance(predicate, ast.Bool):
+        return f'{predicate.name}'
+    elif isinstance(predicate, ast.BoolLiteral):
+        return f'{predicate.V}'
+    elif isinstance(predicate, ast.Int):
+        return f'{predicate.name}'
+    elif isinstance(predicate, ast.IntLiteral):
+        return f'{predicate.V}'
     else:
         raise Exception(f"unknown predicate type: {type(predicate)}")
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -237,7 +237,7 @@ def t_expr(predicate):
     elif isinstance(predicate, ast.MapIndex):
         return f"{predicate.m.name}[{t_expr(predicate.key)}]"
     elif isinstance(predicate, ast.StringSetMapIndexEquals):
-        return f"({predicate.E.m.name}[{t_expr(predicate.E.key)}] == {t_expr(predicate.V.vals)})"
+        return f"equals({predicate.E.m.name}[{t_expr(predicate.E.key)}], {t_expr(predicate.V.vals)})"
     elif isinstance(predicate, ast.String):
         return predicate.name
     elif isinstance(predicate, ast.StringLiteral):
@@ -261,7 +261,39 @@ def t_expr(predicate):
     elif isinstance(predicate, ast.Concat):
         return f'({t_expr(predicate.L)} + {t_expr(predicate.R)})'
     elif isinstance(predicate, ast.Split):
-        return f'{t_expr(predicate.val)}.split({t_expr(predicate.sep)})'
+        return f'split({t_expr(predicate.val)}, {t_expr(predicate.sep)})'
+    elif isinstance(predicate, ast.StringTuple):
+        return f"[{', '.join(t_expr(p) for p in predicate.vals)}]"
+    elif isinstance(predicate, ast.Upper):
+        return f"upper({t_expr(predicate.val)})"
+    elif isinstance(predicate, ast.Lower):
+        return f"lower({t_expr(predicate.val)})"
+    elif isinstance(predicate, ast.StringList):
+        return predicate.name
+    elif isinstance(predicate, ast.StringListContains):
+        return f"contains({t_expr(predicate.E)}, {t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.StringListFirst):
+        return f"first({t_expr(predicate.E)})"
+    elif isinstance(predicate, ast.StringListAdd):
+        return f"add({t_expr(predicate.E)}, {t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.StringListEquals):
+        return f"equals({t_expr(predicate.E)}, {t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.Replace):
+        return f"replace({t_expr(predicate.val)}, {t_expr(predicate.src)}, {t_expr(predicate.dst)})"
+    elif isinstance(predicate, ast.StringListReplace):
+        return f"replace({t_expr(predicate.E)}, {t_expr(predicate.S)}, {t_expr(predicate.D)})"
+    elif isinstance(predicate, ast.StringListLiteral):
+        return f"[{', '.join(t_expr(p) for p in predicate.vals)}]"
+    elif isinstance(predicate, ast.RegexConstraint):
+        return f"regex({t_expr(predicate.expr)})"
+    elif isinstance(predicate, ast.RegexTuple):
+        return f"[{', '.join(t_expr(p) for p in predicate.vals)}]"
+    elif isinstance(predicate, ast.Matches):
+        return f"matches({t_expr(predicate.E)}, {t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.IterableMatches):
+        return f"matches({t_expr(predicate.E)}, {t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.StringEnum):
+        return predicate.name
     else:
         raise Exception(f"unknown predicate type: {type(predicate)}")
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -214,7 +214,7 @@ def transform_expr(predicate, options=None):
     if isinstance(predicate, ast.Predicate):
         return transform_expr(predicate.expr)
     elif isinstance(predicate, ast.Eq):
-        return t_swi(f"({transform_expr(predicate.L, options)} == {transform_expr(predicate.R, options)})", options)
+        return t_swi(f"{transform_expr(predicate.L, options)} == {transform_expr(predicate.R, options)}", options)
     elif isinstance(predicate, ast.String):
         options.add(predicate.name)
         return predicate.name

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -222,13 +222,15 @@ def t_expr(predicate):
     elif isinstance(predicate, ast.MapIndex):
         return f"{predicate.m.name}[{t_expr(predicate.key)}]"
     elif isinstance(predicate, ast.StringSetMapIndexEquals):
-        return f"contains({predicate.E.m.name}[\"{predicate.E.key}\"], {list(predicate.V.vals)})"
+        return f"contains({predicate.E.m.name}[{t_expr(predicate.E.key)}], {t_expr(predicate.V.vals)})"
     elif isinstance(predicate, ast.String):
         return predicate.name
     elif isinstance(predicate, ast.StringLiteral):
         return f'"{predicate.V}"'
     elif isinstance(predicate, str):
         return f'"{predicate}"'
+    elif isinstance(predicate, tuple):
+        return f"[{', '.join([t_expr(p) for p in predicate])}]"
     else:
         raise Exception(f"unknown predicate type: {type(predicate)}")
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -232,7 +232,7 @@ def t_expr(predicate):
     elif isinstance(predicate, ast.MapIndex):
         return f"{predicate.m.name}[{t_expr(predicate.key)}]"
     elif isinstance(predicate, ast.StringSetMapIndexEquals):
-        return f"contains({predicate.E.m.name}[{t_expr(predicate.E.key)}], {t_expr(predicate.V.vals)})"
+        return f"({predicate.E.m.name}[{t_expr(predicate.E.key)}] == {t_expr(predicate.V.vals)})"
     elif isinstance(predicate, ast.String):
         return predicate.name
     elif isinstance(predicate, ast.StringLiteral):

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -217,6 +217,8 @@ def t_expr(predicate):
         return f"({t_expr(predicate.L)} || {t_expr(predicate.R)})"
     elif isinstance(predicate, ast.And):
         return f"({t_expr(predicate.L)} && {t_expr(predicate.R)})"
+    elif isinstance(predicate, ast.Not):
+        return f"(!{t_expr(predicate.V)})"
     elif isinstance(predicate, ast.String):
         return predicate.name
     elif isinstance(predicate, ast.StringLiteral):

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -182,6 +182,8 @@ class RequestPolicy:
 
 
 class Request(ast.Predicate):
+    scope = "access_request"
+
     def __init__(self, expr):
         ast.Predicate.__init__(self, expr)
 
@@ -190,6 +192,8 @@ class Request(ast.Predicate):
 
 
 class Review(ast.Predicate):
+    scope = "access_review"
+
     def __init__(self, expr):
         ast.Predicate.__init__(self, expr)
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -23,6 +23,9 @@ import z3
 from . import ast
 from .errors import ParameterError
 
+def scoped(cls):
+    cls.scope = cls.__name__.lower()
+    return cls
 
 class Options(ast.Predicate):
     """
@@ -55,12 +58,12 @@ class OptionsSet:
         ]
 
 
+@scoped
 class Node(ast.Predicate):
     """
     Node is SSH node
     """
 
-    scope = "node"
     login = ast.String("node.login")
     labels = ast.StringMap("node.labels")
 
@@ -180,20 +183,16 @@ class RequestPolicy:
     # denials is a list of recorded approvals for policy
     denials = ast.StringSetMap("policy.denials")
 
-
+@scoped
 class Request(ast.Predicate):
-    scope = "access_request"
-
     def __init__(self, expr):
         ast.Predicate.__init__(self, expr)
 
     def traverse(self):
         return self.expr.traverse()
 
-
+@scoped
 class Review(ast.Predicate):
-    scope = "access_review"
-
     def __init__(self, expr):
         ast.Predicate.__init__(self, expr)
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -230,7 +230,7 @@ def t_expr(predicate):
     elif isinstance(predicate, str):
         return f'"{predicate}"'
     elif isinstance(predicate, tuple):
-        return f"[{', '.join([t_expr(p) for p in predicate])}]"
+        return f"[{', '.join(t_expr(p) for p in predicate)}]"
     else:
         raise Exception(f"unknown predicate type: {type(predicate)}")
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -282,8 +282,6 @@ def t_expr(predicate):
         return f"replace({t_expr(predicate.val)}, {t_expr(predicate.src)}, {t_expr(predicate.dst)})"
     elif isinstance(predicate, ast.StringListReplace):
         return f"replace({t_expr(predicate.E)}, {t_expr(predicate.S)}, {t_expr(predicate.D)})"
-    elif isinstance(predicate, ast.StringListLiteral):
-        return f"[{', '.join(t_expr(p) for p in predicate.vals)}]"
     elif isinstance(predicate, ast.RegexConstraint):
         return f"regex({t_expr(predicate.expr)})"
     elif isinstance(predicate, ast.RegexTuple):
@@ -294,6 +292,18 @@ def t_expr(predicate):
         return f"matches({t_expr(predicate.E)}, {t_expr(predicate.V)})"
     elif isinstance(predicate, ast.StringEnum):
         return predicate.name
+    elif isinstance(predicate, ast.StringListContainsRegex):
+        return f"contains_regex({t_expr(predicate.E)}, {t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.IterableContains):
+        return f"contains({t_expr(predicate.E)}, {t_expr(predicate.V)})"
+    elif isinstance(predicate, ast.If):
+        return f"if({t_expr(predicate.cond)}, {t_expr(predicate.on_true)}, {t_expr(predicate.on_false)})"
+    elif isinstance(predicate, ast.Select):
+        return f"select([{', '.join(t_expr(p) for p in predicate.cases)}], {t_expr(predicate.default)})"
+    elif isinstance(predicate, ast.Case):
+        return f"case({t_expr(predicate.when)}, {t_expr(predicate.then)})"
+    elif isinstance(predicate, ast.Default):
+        return f"default({t_expr(predicate.expr)})"
     else:
         raise Exception(f"unknown predicate type: {type(predicate)}")
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -209,6 +209,7 @@ class Rules:
     def collect_like(self, other: ast.Predicate):
         return [r for r in self.rules if r.__class__ == other.__class__]
 
+
 # t_expr transforms a predicate-lang expression into a Teleport predicate expression which can be evaluated.
 def t_expr(predicate):
     # special-case predicate subclasses like Node to get their inner expression
@@ -216,7 +217,7 @@ def t_expr(predicate):
         if hasattr(predicate, "scope"):
             # if the predicate has an evaluation scope for which it is only enabled,
             # case it's expression within a `scope` call to allow defaulting in the expression evaluator
-            return f"scope({t_expr(predicate.expr)}, \"{predicate.scope}\")"
+            return f'scope({t_expr(predicate.expr)}, "{predicate.scope}")'
         else:
             return t_expr(predicate.expr)
     elif isinstance(predicate, ast.Eq):


### PR DESCRIPTION
This PR is intended to go hand-in-hand with https://github.com/gravitational/teleport/pull/17220. It adds a shortcut for exporting the policy YAML and ingesting it into a Teleport cluster (by calling into `tctl`) and improves the expression translator to be able to translate more complex predicate-lang policies into the resource representation.

With https://github.com/gravitational/teleport/pull/17220 compiled & running and `tctl` in path. One can now run `predicate deploy examples/access.py` containing the following policy
```py
class Teleport:
    p = Policy(
        name="access",
        loud=False,
        allow=Rules(
            Node(
                ((Node.login == User.name) & (User.name != "root"))
                | (User.traits["team"] == ("admins",))
            ),
        ),
        options=OptionsSet(Options((Options.max_session_ttl < Duration.new(hours=10)))),
        deny=Rules(
            Node(
                (Node.login == "mike")
                | (Node.login == "jester")
                | (Node.labels["env"] == "prod")
            ),
        ),
    )

    def test_access(self):
        # Alice will be able to login to any machine as herself
        ret, _ = self.p.check(
            Node(
                (Node.login == "alice")
                & (User.name == "alice")
                & (Node.labels["env"] == "dev")
            )
        )
        assert ret is True, "Alice can login with her user to any node"

        # No one is permitted to login as mike
        ret, _ = self.p.query(Node((Node.login == "mike")))
        assert ret is False, "This role does not allow access as mike"

        # No one is permitted to login as jester
        ret, _ = self.p.query(Node((Node.login == "jester")))
        assert ret is False, "This role does not allow access as jester"
```

This will translate the policy into the Teleport policy format and automatically write it to the cluster. Once that is done, one can run `tctl get policy/access` and they will see the following YAML policy in the terminal:
```yaml
kind: policy
metadata:
  id: 1665420264035364000
  name: access
spec:
  allow: scope((((node.login == user.name) && (!(user.name == "root"))) || (user.traits["team"]
    == ["admins"])), "node")
  deny: scope((((node.login == "mike") || (node.login == "jester")) || (node.labels["env"]
    == "prod")), "node")
  options: (options.max_session_ttl < 36000000000000)
version: v1
```