### PR TITLE
Reduce magic by using explicit imports for policies

### DIFF
--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -5,31 +5,6 @@ from types import FunctionType
 import click
 import yaml
 
-from solver import (
-    Case,
-    Default,
-    Duration,
-    ParameterError,
-    Predicate,
-    Select,
-    StringLiteral,
-    StringSetMap,
-)
-from solver.teleport import (
-    LoginRule,
-    Node,
-    Options,
-    OptionsSet,
-    Policy,
-    PolicyMap,
-    PolicySet,
-    Request,
-    Review,
-    Rules,
-    User,
-    map_policies,
-    try_login,
-)
 
 @click.group()
 def main():

--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -14,7 +14,6 @@ def main():
 @main.command()
 @click.argument("policy-file")
 def export(policy_file):
-    # Ugly python hack to load a module with a defined environment
     module = run_path(policy_file)
 
     # Grabs the class and directly reads the policy since it's a static member.
@@ -48,7 +47,6 @@ def deploy(policy_file, sudo):
 @main.command()
 @click.argument("policy-file")
 def test(policy_file):
-    # Ugly python hack to load a module with a defined environment
     module = run_path(policy_file)
 
     # Extract the defined policy class and filter out all test functions

--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -31,36 +31,6 @@ from solver.teleport import (
     try_login,
 )
 
-env = {
-    item.__name__: item
-    for item in [
-        # General
-        Case,
-        Default,
-        Duration,
-        ParameterError,
-        Predicate,
-        Select,
-        StringLiteral,
-        StringSetMap,
-        # Teleport
-        LoginRule,
-        Node,
-        Options,
-        OptionsSet,
-        Policy,
-        PolicyMap,
-        PolicySet,
-        Request,
-        Review,
-        Rules,
-        map_policies,
-        try_login,
-        User,
-    ]
-}
-
-
 @click.group()
 def main():
     pass
@@ -70,7 +40,7 @@ def main():
 @click.argument("policy-file")
 def export(policy_file):
     # Ugly python hack to load a module with a defined environment
-    module = run_path(policy_file, env)
+    module = run_path(policy_file)
 
     # Grabs the class and directly reads the policy since it's a static member.
     policy = module["Teleport"].p
@@ -86,7 +56,7 @@ def export(policy_file):
 @click.option("--sudo", "-s", is_flag=True)
 def deploy(policy_file, sudo):
     click.echo("parsing policy...")
-    module = run_path(policy_file, env)
+    module = run_path(policy_file)
     policy = module["Teleport"].p
     click.echo("translating policy...")
     obj = policy.export()
@@ -104,7 +74,7 @@ def deploy(policy_file, sudo):
 @click.argument("policy-file")
 def test(policy_file):
     # Ugly python hack to load a module with a defined environment
-    module = run_path(policy_file, env)
+    module = run_path(policy_file)
 
     # Extract the defined policy class and filter out all test functions
     policyClass = module["Teleport"]

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -1,3 +1,6 @@
+from solver.ast import Duration
+from solver.teleport import Policy, Rules, Node, User, OptionsSet, Options
+
 class Teleport:
     p = Policy(
         name="access",

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -1,5 +1,6 @@
 from solver.ast import Duration
-from solver.teleport import Policy, Rules, Node, User, OptionsSet, Options
+from solver.teleport import Node, Options, OptionsSet, Policy, Rules, User
+
 
 class Teleport:
     p = Policy(

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -23,9 +23,11 @@ import z3
 from . import ast
 from .errors import ParameterError
 
+
 def scoped(cls):
     cls.scope = cls.__name__.lower()
     return cls
+
 
 class Options(ast.Predicate):
     """
@@ -183,6 +185,7 @@ class RequestPolicy:
     # denials is a list of recorded approvals for policy
     denials = ast.StringSetMap("policy.denials")
 
+
 @scoped
 class Request(ast.Predicate):
     def __init__(self, expr):
@@ -190,6 +193,7 @@ class Request(ast.Predicate):
 
     def traverse(self):
         return self.expr.traverse()
+
 
 @scoped
 class Review(ast.Predicate):


### PR DESCRIPTION
This PR fixes #18 by using explicit imports. The current system was devised pre-poetry as I didn't have a good way to manage imports without installing stuff globally. This isn't an issue in the dev environment thanks to `poetry shell` and we can now directly import from the `solver` package within the policy. Using VSCode with the Python Language Server extension now plays nicely with policy files as a result.