### PR TITLE
Add `JoinSession` to model both `join_sessions` and `require_session_join`

### DIFF
--- a/predicate/examples/join_session.py
+++ b/predicate/examples/join_session.py
@@ -1,0 +1,37 @@
+from solver.teleport import JoinSession, Policy, Rules, User
+from solver.ast import Predicate
+
+
+class Teleport:
+    p = Policy(
+        name="join_session",
+        loud=False,
+        allow=Rules(
+            # Equivalent to `join_sessions`:
+            # https://goteleport.com/docs/access-controls/guides/moderated-sessions/#join_sessions
+            JoinSession(
+                (JoinSession.count == 1) &
+                ((JoinSession.mode == "peer") | (JoinSession.mode == "observer")) &
+                (JoinSession.on_leave == "pause")
+            ),
+        ),
+    )
+
+    def test_access(self):
+        ret, _ = self.p.check(
+            JoinSession(
+                (JoinSession.count == 1) &
+                (JoinSession.mode == "observer") &
+                (JoinSession.on_leave == "pause")
+            )
+        )
+        assert ret is True, "any single user (with this policy) can join a session as an observer"
+
+        ret, _ = self.p.check(
+            JoinSession(
+                (JoinSession.count == 1) &
+                (JoinSession.mode == "moderator") &
+                (JoinSession.on_leave == "pause")
+            )
+        )
+        assert ret is False, "any single user (with this policy) cannot join a session as a moderator"

--- a/predicate/examples/join_session_requires.py
+++ b/predicate/examples/join_session_requires.py
@@ -1,0 +1,50 @@
+from solver.teleport import JoinSession, Policy, Rules, User
+from solver.ast import Predicate
+
+
+class Teleport:
+    p = Policy(
+        name="join_session_requires",
+        loud=False,
+        allow=Rules(
+            # Equivalent to `require_session_join`:
+            # https://goteleport.com/docs/access-controls/guides/moderated-sessions/#require_session_join
+            JoinSession(
+                (User.traits["team"].contains("admin")) &
+                (JoinSession.count == 2) &
+                (JoinSession.mode == "moderator") &
+                (JoinSession.on_leave == "terminate")
+            )
+        ),
+    )
+
+    def test_access(self):
+        ret, _ = self.p.check(
+            JoinSession(
+                (User.traits["team"] == ("admin",)) &
+                (JoinSession.count == 2) &
+                (JoinSession.mode == "moderator") &
+                (JoinSession.on_leave == "terminate")
+            )
+        )
+        assert ret is True, "any two users (with this policy) from the admin team can join a session as moderators"
+
+        ret, _ = self.p.check(
+            JoinSession(
+                (User.traits["team"] == ("dev",)) &
+                (JoinSession.count == 2) &
+                (JoinSession.mode == "moderator") &
+                (JoinSession.on_leave == "terminate")
+            )
+        )
+        assert ret is False, "any two users (with this policy) from the dev team cannot join a session as moderators"
+
+        ret, _ = self.p.check(
+            JoinSession(
+                (User.traits["team"] == ("admin",)) &
+                (JoinSession.count == 1) &
+                (JoinSession.mode == "moderator") &
+                (JoinSession.on_leave == "terminate")
+            )
+        )
+        assert ret is False, "a single user (with this policy) from the admin team cannot join a session as moderators"

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -81,6 +81,21 @@ class Node(ast.Predicate):
         """
         return Node(self.expr & options.expr)
 
+@scoped
+class JoinSession(ast.Predicate):
+    """
+    JoinSession defines the permission to join a moderated session.
+
+    Full documentation here: https://goteleport.com/docs/access-controls/guides/moderated-sessions
+    Note that this predicate models both `join_sessions` and `require_session_join`.
+    """
+
+    mode = ast.String("join_session.mode")
+    on_leave = ast.String("join_session.on_leave")
+    count = ast.Int("join_session.count")
+
+    def __init__(self, expr):
+        ast.Predicate.__init__(self, expr)
 
 class LoginRule(ast.StringSetMap):
     """


### PR DESCRIPTION
This PR models both `join_sessions` and `require_session_join` (https://goteleport.com/docs/access-controls/guides/moderated-sessions/) using a single `JoinSession` predicate (in the most straightforward way following #24).

My understanding is that `require_session_join` generalizes `join_sessions` (i.e. there's nothing that can be written using `join_sessions` that cannot be written using `require_session_join`). For this reason, this PR adds a single `JoinSession` predicate.

Note that the `roles` field in `join_sessions` and the `filter` field in `require_session_join` are not part of the `JoinSession` object as they can be specified using `User` object (see `predicate/examples/join_session_requires.py`).

Below is the export of two examples added:

```yaml
kind: policy
metadata:
  name: join_session
spec:
  allow:
    joinsession: (((join_session.count == 1) && ((join_session.mode == "peer") ||
      (join_session.mode == "observer"))) && (join_session.on_leave == "pause"))
version: v1
```

```yaml
kind: policy
metadata:
  name: join_session_requires
spec:
  allow:
    joinsession: (((contains(user.traits["team"], "admin") && (join_session.count
      == 2)) && (join_session.mode == "moderator")) && (join_session.on_leave == "terminate"))
version: v1
```