### PR TITLE
Ensure that only `<` can be used in `max_session_ttl` predicates

### DIFF
--- a/predicate/solver/ast.py
+++ b/predicate/solver/ast.py
@@ -459,11 +459,34 @@ class Duration:
             + nanoseconds * NANOSECOND
         )
 
+    def __eq__(self, val):
+        if isinstance(val, (Duration, DurationLiteral)):
+            return Eq(self, val)
+        raise TypeError(
+            "unsupported type {}, supported duration and duration literals only".format(type(val))
+        )
+
+    def __ne__(self, val):
+        if isinstance(val, (Duration, DurationLiteral)):
+            return Not(Eq(self, val))
+        raise TypeError(
+            "unsupported type {}, supported duration and duration literals only".format(type(val))
+        )
+
     def __lt__(self, val):
         if isinstance(val, (Duration, DurationLiteral)):
             return Lt(self, val)
         raise TypeError(
-            "unsupported type {}, supported integers only".format(type(val))
+            "unsupported type {}, supported duration and duration literals only".format(type(val))
+        )
+
+    def __gt__(self, val):
+        if isinstance(val, (Duration, DurationLiteral)):
+            return Gt(self, val)
+        raise TypeError(
+            "unsupported type {}, supported duration and duration literals only".format(
+                type(val)
+            )
         )
 
 
@@ -478,7 +501,7 @@ class Bool:
         if isinstance(val, (Bool,)):
             return Eq(self, val)
         raise TypeError(
-            "unsupported type {}, supported integers only".format(type(val))
+            "unsupported type {}, supported booleans only".format(type(val))
         )
 
     def __ne__(self, val):
@@ -487,7 +510,7 @@ class Bool:
         if isinstance(val, (Bool,)):
             return Not(Eq(self, val))
         raise TypeError(
-            "unsupported type {}, supported integers only".format(type(val))
+            "unsupported type {}, supported booleans only".format(type(val))
         )
 
     def traverse(self):

--- a/predicate/solver/ast.py
+++ b/predicate/solver/ast.py
@@ -459,34 +459,11 @@ class Duration:
             + nanoseconds * NANOSECOND
         )
 
-    def __eq__(self, val):
-        if isinstance(val, (Duration, DurationLiteral)):
-            return Eq(self, val)
-        raise TypeError(
-            "unsupported type {}, supported integers only".format(type(val))
-        )
-
-    def __ne__(self, val):
-        if isinstance(val, (Duration, DurationLiteral)):
-            return Not(Eq(self, val))
-        raise TypeError(
-            "unsupported type {}, supported integers only".format(type(val))
-        )
-
     def __lt__(self, val):
         if isinstance(val, (Duration, DurationLiteral)):
             return Lt(self, val)
         raise TypeError(
             "unsupported type {}, supported integers only".format(type(val))
-        )
-
-    def __gt__(self, val):
-        if isinstance(val, (Duration, DurationLiteral)):
-            return Gt(self, val)
-        raise TypeError(
-            "unsupported type {}, supported duration and duration literals only".format(
-                type(val)
-            )
         )
 
 

--- a/predicate/solver/ast.py
+++ b/predicate/solver/ast.py
@@ -444,18 +444,8 @@ class LtDuration:
     def __str__(self):
         return "ltduration({})".format(self.name)
 
-    def __lt__(self, val):
-        self.check_value_is_valid(val)
+    def __lt__(self, val: DurationLiteral):
         return Lt(self, val)
-
-    def check_value_is_valid(self, val):
-        if isinstance(val, DurationLiteral):
-            return
-        raise TypeError(
-            "unsupported type {}, supported duration literals only".format(
-                type(val)
-            )
-        )
 
 
 class Duration(LtDuration):
@@ -484,16 +474,13 @@ class Duration(LtDuration):
     def __str__(self):
         return "duration({})".format(self.name)
 
-    def __eq__(self, val):
-        self.check_value_is_valid(val)
+    def __eq__(self, val: DurationLiteral):
         return Eq(self, val)
 
-    def __ne__(self, val):
-        self.check_value_is_valid(val)
+    def __ne__(self, val: DurationLiteral):
         return Not(Eq(self, val))
 
-    def __gt__(self, val):
-        self.check_value_is_valid(val)
+    def __gt__(self, val: DurationLiteral):
         return Gt(self, val)
 
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -24,8 +24,6 @@ from . import ast
 from .errors import ParameterError
 
 
-OPTIONS_MAX_SESSION_TTL_NAME = "options.max_session_ttl"
-
 def scoped(cls):
     cls.scope = cls.__name__.lower()
     return cls
@@ -36,7 +34,7 @@ class Options(ast.Predicate):
     Options apply to some allow rules if they match
     """
 
-    max_session_ttl = ast.Duration(OPTIONS_MAX_SESSION_TTL_NAME)
+    max_session_ttl = ast.LtDuration("options.max_session_ttl")
 
     pin_source_ip = ast.Bool("options.pin_source_ip")
 
@@ -45,13 +43,7 @@ class Options(ast.Predicate):
     )
 
     def __init__(self, expr):
-        expr.walk(check_options_are_valid)
         ast.Predicate.__init__(self, expr)
-
-def check_options_are_valid(expr):
-    # check that only '<' inequalities are used with Options.max_session_ttl
-    if isinstance(expr, (ast.Eq, ast.Gt)) and isinstance(expr.L, ast.Duration) and expr.L.name == OPTIONS_MAX_SESSION_TTL_NAME:
-        raise SystemExit("{} predicates can only use '<' inequalities, not '>', '==' or '!=': {}".format(OPTIONS_MAX_SESSION_TTL_NAME, expr))
 
 
 class OptionsSet:
@@ -246,6 +238,7 @@ def t_expr(predicate):
         predicate,
         (
             ast.String,
+            ast.LtDuration,
             ast.Duration,
             ast.StringList,
             ast.StringEnum,

--- a/predicate/solver/test/test_ast.py
+++ b/predicate/solver/test/test_ast.py
@@ -805,25 +805,22 @@ class TestAst:
 
     def test_duration(self):
         """
-        Test int tests integer operations
+        Test duration tests duration inequalities
         """
         p = Predicate(
-            Options.ttl == Duration.new(hours=5),
+            Options.ttl < Duration.new(hours=5),
         )
 
-        ret, _ = p.check(Predicate(Options.ttl == Duration.new(hours=5)))
+        ret, _ = p.check(Predicate(Options.ttl < Duration.new(hours=5)))
         assert ret is True, "solves with simple equality check"
 
         p = Predicate(
-            (Options.ttl > Duration.new(seconds=10))
+            (Options.ttl < Duration.new(seconds=10))
             & (Options.ttl < Duration.new(hours=5))
         )
 
-        ret, _ = p.check(Predicate(Options.ttl == Duration.new(hours=3)))
-        assert ret is True, "solves with simple boundary check"
-
-        ret, _ = p.check(Predicate(Options.ttl == Duration.new(hours=6)))
-        assert ret is False, "solves with simple boundary check"
+        ret, _ = p.check(Predicate(Options.ttl < Duration.new(hours=30)))
+        assert ret is True, "solves always for < inequalities with durations"
 
     def test_bool(self):
         """

--- a/predicate/solver/test/test_ast.py
+++ b/predicate/solver/test/test_ast.py
@@ -805,22 +805,25 @@ class TestAst:
 
     def test_duration(self):
         """
-        Test duration tests duration inequalities
+        Test int tests integer operations
         """
         p = Predicate(
-            Options.ttl < Duration.new(hours=5),
+            Options.ttl == Duration.new(hours=5),
         )
 
-        ret, _ = p.check(Predicate(Options.ttl < Duration.new(hours=5)))
+        ret, _ = p.check(Predicate(Options.ttl == Duration.new(hours=5)))
         assert ret is True, "solves with simple equality check"
 
         p = Predicate(
-            (Options.ttl < Duration.new(seconds=10))
+            (Options.ttl > Duration.new(seconds=10))
             & (Options.ttl < Duration.new(hours=5))
         )
 
-        ret, _ = p.check(Predicate(Options.ttl < Duration.new(hours=30)))
-        assert ret is True, "solves always for < inequalities with durations"
+        ret, _ = p.check(Predicate(Options.ttl == Duration.new(hours=3)))
+        assert ret is True, "solves with simple boundary check"
+
+        ret, _ = p.check(Predicate(Options.ttl == Duration.new(hours=6)))
+        assert ret is False, "solves with simple boundary check"
 
     def test_bool(self):
         """

--- a/predicate/solver/test/test_teleport.py
+++ b/predicate/solver/test/test_teleport.py
@@ -99,12 +99,22 @@ class TestTeleport:
     def test_valid_options(self):
         # check that only < inequalities are possible
         _ = Options(Options.max_session_ttl < Duration.new(hours=3))
+        _ = Options(Duration.new(hours=3) > Options.max_session_ttl)
+
         with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
             _ = Options(Options.max_session_ttl > Duration.new(hours=3))
         with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+            _ = Options(Duration.new(hours=3) < Options.max_session_ttl)
+
+        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
             _ = Options(Options.max_session_ttl == Duration.new(hours=3))
         with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+            _ = Options(Duration.new(hours=3) == Options.max_session_ttl)
+
+        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
             _ = Options(Options.max_session_ttl != Duration.new(hours=3))
+        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+            _ = Options(Duration.new(hours=3) != Options.max_session_ttl)
 
     def test_options(self):
         p = Policy(

--- a/predicate/solver/test/test_teleport.py
+++ b/predicate/solver/test/test_teleport.py
@@ -101,19 +101,19 @@ class TestTeleport:
         _ = Options(Options.max_session_ttl < Duration.new(hours=3))
         _ = Options(Duration.new(hours=3) > Options.max_session_ttl)
 
-        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+        with pytest.raises(Exception):
             _ = Options(Options.max_session_ttl > Duration.new(hours=3))
-        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+        with pytest.raises(Exception):
             _ = Options(Duration.new(hours=3) < Options.max_session_ttl)
 
-        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+        with pytest.raises(Exception):
             _ = Options(Options.max_session_ttl == Duration.new(hours=3))
-        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+        with pytest.raises(Exception):
             _ = Options(Duration.new(hours=3) == Options.max_session_ttl)
 
-        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+        with pytest.raises(Exception):
             _ = Options(Options.max_session_ttl != Duration.new(hours=3))
-        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+        with pytest.raises(Exception):
             _ = Options(Duration.new(hours=3) != Options.max_session_ttl)
 
     def test_options(self):

--- a/predicate/solver/test/test_teleport.py
+++ b/predicate/solver/test/test_teleport.py
@@ -96,6 +96,16 @@ class TestTeleport:
         )
         assert ret is True, "non-denied part of allow is OK"
 
+    def test_valid_options(self):
+        # check that only < inequalities are possible
+        _ = Options(Options.max_session_ttl < Duration.new(hours=3))
+        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+            _ = Options(Options.max_session_ttl > Duration.new(hours=3))
+        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+            _ = Options(Options.max_session_ttl == Duration.new(hours=3))
+        with pytest.raises(SystemExit, match=r"can only use '<' inequalities"):
+            _ = Options(Options.max_session_ttl != Duration.new(hours=3))
+
     def test_options(self):
         p = Policy(
             name="b",

--- a/predicate/solver/test/test_teleport.py
+++ b/predicate/solver/test/test_teleport.py
@@ -404,6 +404,7 @@ class TestTeleport:
             & (traits["login"] == ("alice-wonderland.local",))
         )
         ret, _ = p.solve()
+        assert ret is True, "match and replace works in login rules"
 
         s = PolicyMap(
             Select(
@@ -420,13 +421,13 @@ class TestTeleport:
             (s == ("ext-test", "ext-prod"))
             & (external["groups"] == ("admin-test", "admin-prod"))
         ).solve()
-        assert ret is True, "match and replace works"
+        assert ret is True, "match and replace works in policy maps"
 
         ret, _ = Predicate(
             (s == ("dev-test", "dev-prod"))
             & (external["groups"] == ("dev-test", "dev-prod"))
         ).solve()
-        assert ret is True, "match and replace works default value"
+        assert ret is True, "match and replace works in policy maps (default value)"
 
         # dev policy allows access to stage, and denies access to root
         dev = Policy(


### PR DESCRIPTION
As discussed in #27, we want `max_session_ttl` to only contain `<` inequalities, so this PR removes the support for `>`, `==` and `!=`.

Since we can only use `<`, all predicates evaluate to true. For this reason, the tests had to be simplified (and are not as useful now).

---

A follow up PR will implement the solver idea proposed in #27 so that the exported policy simply says `max_session_ttl < N` (even if the predicate has `and`/`or` expressions).
