### PR TITLE
Split `Node` into `NodeAccess` action and `Node` resource

### DIFF
--- a/predicate/README.md
+++ b/predicate/README.md
@@ -82,10 +82,10 @@ metadata:
   name: access
 spec:
   allow:
-    accessnode: (((access_node.login == user.name) && (!(user.name == "root"))) ||
+    access_node: (((access_node.login == user.name) && (!(user.name == "root"))) ||
       equals(user.traits["team"], ["admins"]))
   deny:
-    accessnode: (((access_node.login == "mike") || (access_node.login == "jester"))
+    access_node: (((access_node.login == "mike") || (access_node.login == "jester"))
       || (node.labels["env"] == "prod"))
   options: (options.max_session_ttl < 36000000000000)
 version: v1

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -1,5 +1,5 @@
 from solver.ast import Duration
-from solver.teleport import Node, Options, OptionsSet, Policy, Rules, User
+from solver.teleport import AccessNode, Node, Options, OptionsSet, Policy, Rules, User
 
 
 class Teleport:
@@ -7,16 +7,16 @@ class Teleport:
         name="access",
         loud=False,
         allow=Rules(
-            Node(
-                ((Node.login == User.name) & (User.name != "root"))
+            AccessNode(
+                ((AccessNode.login == User.name) & (User.name != "root"))
                 | (User.traits["team"] == ("admins",))
             ),
         ),
         options=OptionsSet(Options((Options.max_session_ttl < Duration.new(hours=10)))),
         deny=Rules(
-            Node(
-                (Node.login == "mike")
-                | (Node.login == "jester")
+            AccessNode(
+                (AccessNode.login == "mike")
+                | (AccessNode.login == "jester")
                 | (Node.labels["env"] == "prod")
             ),
         ),
@@ -25,8 +25,8 @@ class Teleport:
     def test_access(self):
         # Alice will be able to login to any machine as herself
         ret, _ = self.p.check(
-            Node(
-                (Node.login == "alice")
+            AccessNode(
+                (AccessNode.login == "alice")
                 & (User.name == "alice")
                 & (Node.labels["env"] == "dev")
             )
@@ -34,9 +34,9 @@ class Teleport:
         assert ret is True, "Alice can login with her user to any node"
 
         # No one is permitted to login as mike
-        ret, _ = self.p.query(Node((Node.login == "mike")))
+        ret, _ = self.p.query(AccessNode((AccessNode.login == "mike")))
         assert ret is False, "This role does not allow access as mike"
 
         # No one is permitted to login as jester
-        ret, _ = self.p.query(Node((Node.login == "jester")))
+        ret, _ = self.p.query(AccessNode((AccessNode.login == "jester")))
         assert ret is False, "This role does not allow access as jester"

--- a/predicate/examples/join_session.py
+++ b/predicate/examples/join_session.py
@@ -1,4 +1,4 @@
-from solver.teleport import JoinSession, Session, Policy, Rules, User, Node
+from solver.teleport import JoinSession, Session, Policy, Rules, User, AccessNode
 
 
 class Teleport:

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -19,13 +19,14 @@ import operator
 from collections.abc import Iterable
 
 import z3
+import re
 
 from . import ast
 from .errors import ParameterError
 
 
 def scoped(cls):
-    cls.scope = cls.__name__.lower()
+    cls.scope = re.sub(r"([a-z])([A-Z])", r'\1_\2', cls.__name__).lower()
     return cls
 
 

--- a/predicate/solver/teleport.py
+++ b/predicate/solver/teleport.py
@@ -61,13 +61,12 @@ class OptionsSet:
 
 
 @scoped
-class Node(ast.Predicate):
+class AccessNode(ast.Predicate):
     """
-    Node is SSH node
+    AccessNode defines the permission to access an SSH node.
     """
 
-    login = ast.String("node.login")
-    labels = ast.StringMap("node.labels")
+    login = ast.String("access_node.login")
 
     def __init__(self, expr):
         ast.Predicate.__init__(self, expr)
@@ -79,7 +78,16 @@ class Node(ast.Predicate):
         so this operator constructs a node predicate that contains options
         that are relevant to node.
         """
-        return Node(self.expr & options.expr)
+        return AccessNode(self.expr & options.expr)
+
+
+class Node:
+    """
+    Node is an SSH node.
+    """
+
+    # labels are the node labels
+    labels = ast.StringMap("node.labels")
 
 
 class LoginRule(ast.StringSetMap):
@@ -196,7 +204,7 @@ class JoinSession(ast.Predicate):
 
 class Session:
     """
-    Session is a Teleport session
+    Session is a Teleport session.
     """
 
     # owner is the session owner

--- a/predicate/solver/test/test_teleport.py
+++ b/predicate/solver/test/test_teleport.py
@@ -14,6 +14,7 @@ from ..teleport import (
     LoginRule,
     User,
     Node,
+    AccessNode,
     Options,
     OptionsSet,
     Policy,
@@ -32,13 +33,13 @@ class TestTeleport:
         p = Policy(
             name="test",
             allow=Rules(
-                Node((Node.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
             ),
         )
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -49,36 +50,36 @@ class TestTeleport:
         a = Policy(
             name="a",
             allow=Rules(
-                Node((Node.login == "ubuntu") & (Node.labels["env"] == "prod")),
+                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod")),
             ),
         )
 
         b = Policy(
             name="b",
             allow=Rules(
-                Node((Node.login == "root") & (Node.labels["env"] == "stage")),
+                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "stage")),
             ),
         )
 
         s = PolicySet([a, b])
         ret, _ = s.check(
-            Node((Node.login == "ubuntu") & (Node.labels["env"] == "prod"))
+            AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod"))
         )
         assert ret is True, "check works on a subset"
 
-        ret, _ = s.check(Node((Node.login == "root") & (Node.labels["env"] == "stage")))
+        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "stage")))
         assert ret is True, "check works on a subset"
 
-        ret, _ = s.check(Node((Node.login == "root") & (Node.labels["env"] == "prod")))
+        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
         assert ret is False, "rejects the merge"
 
     def test_deny_policy_set(self):
         a = Policy(
             name="a",
             allow=Rules(
-                Node(
-                    ((Node.login == "root") & (Node.labels["env"] == "prod"))
-                    | ((Node.login == "ubuntu") & (Node.labels["env"] == "prod"))
+                AccessNode(
+                    ((AccessNode.login == "root") & (Node.labels["env"] == "prod"))
+                    | ((AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod"))
                 )
             ),
         )
@@ -86,16 +87,16 @@ class TestTeleport:
         b = Policy(
             name="b",
             deny=Rules(
-                Node((Node.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
             ),
         )
 
         s = PolicySet([a, b])
-        ret, _ = s.check(Node((Node.login == "root") & (Node.labels["env"] == "prod")))
+        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
         assert ret is False, "deny in a set overrides allow"
 
         ret, _ = s.check(
-            Node((Node.login == "ubuntu") & (Node.labels["env"] == "prod"))
+            AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod"))
         )
         assert ret is True, "non-denied part of allow is OK"
 
@@ -109,13 +110,13 @@ class TestTeleport:
                 )
             ),
             allow=Rules(
-                Node((Node.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
             ),
         )
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -125,8 +126,8 @@ class TestTeleport:
         assert ret is True, "options and core predicate matches"
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -150,13 +151,13 @@ class TestTeleport:
             ),
             allow=Rules(
                 # unrelated rules are with comma, related rules are part of the predicate
-                Node((Node.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
             ),
         )
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -166,8 +167,8 @@ class TestTeleport:
         assert ret is True, "options and core predicate matches"
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -190,22 +191,22 @@ class TestTeleport:
                 Options(Options.pin_source_ip == True),
             ),
             allow=Rules(
-                Node((Node.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
             ),
         )
 
         b = Policy(
             name="b",
             allow=Rules(
-                Node((Node.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
             ),
         )
 
         p = PolicySet([a, b])
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -215,8 +216,8 @@ class TestTeleport:
         assert ret is True, "options and core predicate matches"
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -239,7 +240,7 @@ class TestTeleport:
                 ),
             ),
             allow=Rules(
-                Node((Node.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
             ),
         )
 
@@ -250,15 +251,15 @@ class TestTeleport:
                 Options(Options.recording_mode == "strict"),
             ),
             allow=Rules(
-                Node((Node.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
             ),
         )
 
         p = PolicySet([a, b])
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -268,8 +269,8 @@ class TestTeleport:
         assert ret is True, "options and core predicate matches"
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "root")
+            AccessNode(
+                (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
@@ -281,8 +282,8 @@ class TestTeleport:
         ), "options fails recording mode restriction from the policy b"
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "ubuntu")
+            AccessNode(
+                (AccessNode.login == "ubuntu")
                 & (Node.labels["env"] == "stage")
                 & (Node.labels["os"] == "Linux")
             )
@@ -292,8 +293,8 @@ class TestTeleport:
         assert ret is True, "options and core predicate matches"
 
         ret, _ = p.check(
-            Node(
-                (Node.login == "ubuntu")
+            AccessNode(
+                (AccessNode.login == "ubuntu")
                 & (Node.labels["env"] == "stage")
                 & (Node.labels["os"] == "Linux")
             )
@@ -473,10 +474,10 @@ class TestTeleport:
         dev = Policy(
             name="dev-stage",
             allow=Rules(
-                Node((Node.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
             ),
             deny=Rules(
-                Node((Node.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
             ),
         )
 
@@ -488,8 +489,8 @@ class TestTeleport:
                 Options(Options.recording_mode == "strict"),
             ),
             allow=Rules(
-                Node(
-                    (Node.login == traits["login"].first())
+                AccessNode(
+                    (AccessNode.login == traits["login"].first())
                     & (Node.labels["env"] == "prod")
                 ),
             ),
@@ -498,7 +499,7 @@ class TestTeleport:
         p = PolicySet([dev, ext])
 
         # make sure that policy set will never allow access to prod
-        ret, _ = p.check(Node((Node.login == "root") & (Node.labels["env"] == "prod")))
+        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
         assert ret is False
 
         policy_names = try_login(
@@ -512,8 +513,8 @@ class TestTeleport:
         # policy set will allow Alice to connect to prod if her
         # email is alice@wonderland.local
         ret, _ = p.check(
-            Node(
-                (Node.login == "alice-wonderland.local")
+            AccessNode(
+                (AccessNode.login == "alice-wonderland.local")
                 & (Node.labels["env"] == "prod")
             )
         )

--- a/predicate/solver/test/test_teleport_get_started.py
+++ b/predicate/solver/test/test_teleport_get_started.py
@@ -1,4 +1,4 @@
-from ..teleport import Node, Policy, Rules, User
+from ..teleport import AccessNode, Node, Policy, Rules, User
 
 
 class TestTeleportGetStarted:
@@ -13,12 +13,12 @@ class TestTeleportGetStarted:
         p = Policy(
             name="everyone",
             allow=Rules(
-                Node((Node.login == "root")),
+                AccessNode((AccessNode.login == "root")),
             ),
         )
 
         # Check if alice can access nodes as root
-        ret, _ = p.check(Node((Node.login == "root") & (User.name == "alice")))
+        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (User.name == "alice")))
         assert ret is True, "everyone can access as root, including alice"
 
         # This is not a very useful policy, because it gives everyone
@@ -27,19 +27,19 @@ class TestTeleportGetStarted:
         p = Policy(
             name="everyone",
             allow=Rules(
-                Node((Node.login == User.name)),
+                AccessNode((AccessNode.login == User.name)),
             ),
         )
 
         # Alice will be able to login to any machine as herself
-        ret, _ = p.check(Node((Node.login == "alice") & (User.name == "alice")))
+        ret, _ = p.check(AccessNode((AccessNode.login == "alice") & (User.name == "alice")))
         assert ret is True, "Alice can login with her user to any node"
 
         # We can verify that a strong invariant holds:
         # Unless a username is root, a user can not access a server as
         # root. This creates a problem though, can we deny access as root
         # altogether?
-        ret, _ = p.check(Node((Node.login == "root") & (User.name != "root")))
+        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (User.name != "root")))
         assert (
             ret is False
         ), "This role does not allow access as root unless a user name is root"
@@ -49,16 +49,16 @@ class TestTeleportGetStarted:
         p = Policy(
             name="everyone",
             allow=Rules(
-                Node(Node.login == User.name),
+                AccessNode(AccessNode.login == User.name),
             ),
-            deny=Rules(Node(Node.login == "root")),
+            deny=Rules(AccessNode(AccessNode.login == "root")),
         )
 
         # Notice the difference between check and query. Query allows to query
         # partial conditions, our predicate requires user to be specified,
         # while this query does not specify any user. Checks require all
         # parameters of the predicate, while queries do not.
-        ret, _ = p.query(Node((Node.login == "root")))
+        ret, _ = p.query(AccessNode((AccessNode.login == "root")))
         assert ret is False, "This role does not allow access as root to anyone"
 
     def test_node_access_multiple_teams(self):
@@ -74,8 +74,8 @@ class TestTeleportGetStarted:
         devs_and_admins = Policy(
             name="devs-and-db-admins",
             allow=Rules(
-                Node(
-                    (Node.login == User.name)
+                AccessNode(
+                    (AccessNode.login == User.name)
                     & User.traits["team"].contains(Node.labels["team"])
                 ),
             ),
@@ -83,10 +83,10 @@ class TestTeleportGetStarted:
 
         # Check if alice can access nodes as root
         ret, _ = devs_and_admins.check(
-            Node(
+            AccessNode(
                 (User.name == "alice")
                 & (User.traits["team"] == ("dev",))
-                & (Node.login == "alice")
+                & (AccessNode.login == "alice")
                 & (Node.labels["team"] == "dev")
             )
         )
@@ -96,10 +96,10 @@ class TestTeleportGetStarted:
 
         # Check if bob can access nodes as root
         ret, _ = devs_and_admins.check(
-            Node(
+            AccessNode(
                 (User.name == "bob")
                 & (User.traits["team"] == ("db-admins",))
-                & (Node.login == "bob")
+                & (AccessNode.login == "bob")
                 & (Node.labels["team"] == "db-admins")
             )
         )


### PR DESCRIPTION
As discussed in #29, this PR splits `Node` into a `NodeAccess` action and a `Node` resource.

The output of `predicate export` changes with this. For example, for `examples/access.py` we now have:

```yaml
kind: policy
metadata:
  name: access
spec:
  allow:
    access_node: (((access_node.login == user.name) && (!(user.name == "root"))) ||
      equals(user.traits["team"], ["admins"]))
  deny:
    access_node: (((access_node.login == "mike") || (access_node.login == "jester"))
      || (node.labels["env"] == "prod"))
  options: (options.max_session_ttl < 36000000000000)
version: v1
```