### PR TITLE
Combine options outside of Z3

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,4 +17,6 @@ jobs:
           pip install poetry
           poetry install
       - name: Run tests
-        run: 'poetry run make test'
+        run: poetry run make test
+      - name: Run linter
+        run: poetry run make lint-check

--- a/predicate/Makefile
+++ b/predicate/Makefile
@@ -1,16 +1,15 @@
-all:
+all: lint test
 
 .PHONY: test-%
 test-%:
-	mypy solver/test/test_$*.py
 	pytest --pyargs solver/test/test_$*.py
 
 .PHONY: lint
 lint:
 	lint-python
 
-.PHONY: check
-check:
+.PHONY: lint-check
+lint-check:
 	lint-python --check
 
 .PHONY: test

--- a/predicate/README.md
+++ b/predicate/README.md
@@ -10,83 +10,16 @@ Alternately, `poetry shell` can also be used to run `predicate`.
 
 ## Working with policies
 
-### Example policy
-
-```py
-# access.py
-
-from solver.ast import Duration
-from solver.teleport import AccessNode, Node, Options, OptionsSet, Policy, Rules, User
-
-
-class Teleport:
-    p = Policy(
-        name="access",
-        loud=False,
-        allow=Rules(
-            AccessNode(
-                ((AccessNode.login == User.name) & (User.name != "root"))
-                | (User.traits["team"] == ("admins",))
-            ),
-        ),
-        options=OptionsSet(Options((Options.max_session_ttl < Duration.new(hours=10)))),
-        deny=Rules(
-            AccessNode(
-                (AccessNode.login == "mike")
-                | (AccessNode.login == "jester")
-                | (Node.labels["env"] == "prod")
-            ),
-        ),
-    )
-
-    def test_access(self):
-        # Alice will be able to login to any machine as herself
-        ret, _ = self.p.check(
-            AccessNode(
-                (AccessNode.login == "alice")
-                & (User.name == "alice")
-                & (Node.labels["env"] == "dev")
-            )
-        )
-        assert ret is True, "Alice can login with her user to any node"
-
-        # No one is permitted to login as mike
-        ret, _ = self.p.query(AccessNode((AccessNode.login == "mike")))
-        assert ret is False, "This role does not allow access as mike"
-
-        # No one is permitted to login as jester
-        ret, _ = self.p.query(AccessNode((AccessNode.login == "jester")))
-        assert ret is False, "This role does not allow access as jester"
-```
+See example policies in the [examples/](examples/) folder.
 
 ### Testing a policy
 
 ```bash
-predicate test access.py
-```
-
-```bash
-Running 1 tests:
-  - test_access: ok
+predicate test examples/access.py
 ```
 
 ### Exporting a policy
 
 ```bash
-predicate export access.py
-```
-
-```yaml
-kind: policy
-metadata:
-  name: access
-spec:
-  allow:
-    access_node: (((access_node.login == user.name) && (!(user.name == "root"))) ||
-      equals(user.traits["team"], ["admins"]))
-  deny:
-    access_node: (((access_node.login == "mike") || (access_node.login == "jester"))
-      || (node.labels["env"] == "prod"))
-  options: (options.max_session_ttl < 36000000000000)
-version: v1
+predicate export examples/access.py
 ```

--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -5,6 +5,8 @@ from types import FunctionType
 import click
 import yaml
 
+from solver.teleport import Policy
+
 
 @click.group()
 def main():
@@ -17,7 +19,7 @@ def export(policy_file):
     module = run_path(policy_file)
 
     # Grabs the class and directly reads the policy since it's a static member.
-    policy = module["Teleport"].p
+    policy: Policy = module["Teleport"].p
 
     # Dump the policy into a Teleport resource and write it to the terminal.
     obj = policy.export()
@@ -31,10 +33,12 @@ def export(policy_file):
 def deploy(policy_file, sudo):
     click.echo("parsing policy...")
     module = run_path(policy_file)
-    policy = module["Teleport"].p
+    policy: Policy = module["Teleport"].p
+
     click.echo("translating policy...")
     obj = policy.export()
     serialized = yaml.dump(obj)
+
     click.echo("deploying policy...")
     args = ["tctl", "create", "-f"]
     if sudo:

--- a/predicate/examples/access.py
+++ b/predicate/examples/access.py
@@ -1,18 +1,31 @@
 from solver.ast import Duration
-from solver.teleport import AccessNode, Node, Options, OptionsSet, Policy, Rules, User
+from solver.teleport import (
+    AccessNode,
+    Node,
+    Options,
+    Policy,
+    RecordingMode,
+    Rules,
+    SourceIp,
+    User,
+)
 
 
 class Teleport:
     p = Policy(
         name="access",
         loud=False,
+        options=Options(
+            max_session_ttl=Duration.new(hours=10),
+            recording_mode=RecordingMode.STRICT,
+            source_ip=SourceIp.PINNED,
+        ),
         allow=Rules(
             AccessNode(
                 ((AccessNode.login == User.name) & (User.name != "root"))
                 | (User.traits["team"] == ("admins",))
             ),
         ),
-        options=OptionsSet(Options((Options.max_session_ttl < Duration.new(hours=10)))),
         deny=Rules(
             AccessNode(
                 (AccessNode.login == "mike")
@@ -24,19 +37,19 @@ class Teleport:
 
     def test_access(self):
         # Alice will be able to login to any machine as herself
-        ret, _ = self.p.check(
+        ret = self.p.check(
             AccessNode(
                 (AccessNode.login == "alice")
                 & (User.name == "alice")
                 & (Node.labels["env"] == "dev")
             )
         )
-        assert ret is True, "Alice can login with her user to any node"
+        assert ret.solves is True, "Alice can login with her user to any node"
 
         # No one is permitted to login as mike
-        ret, _ = self.p.query(AccessNode((AccessNode.login == "mike")))
-        assert ret is False, "This role does not allow access as mike"
+        ret = self.p.query(AccessNode((AccessNode.login == "mike")))
+        assert ret.solves is False, "This role does not allow access as mike"
 
         # No one is permitted to login as jester
-        ret, _ = self.p.query(AccessNode((AccessNode.login == "jester")))
-        assert ret is False, "This role does not allow access as jester"
+        ret = self.p.query(AccessNode((AccessNode.login == "jester")))
+        assert ret.solves is False, "This role does not allow access as jester"

--- a/predicate/examples/join_session.py
+++ b/predicate/examples/join_session.py
@@ -1,4 +1,4 @@
-from solver.teleport import JoinSession, Session, Policy, Rules, User, AccessNode
+from solver.teleport import JoinSession, Policy, Rules, Session, User
 
 
 class Teleport:
@@ -9,51 +9,58 @@ class Teleport:
             # Equivalent to `join_sessions`:
             # https://goteleport.com/docs/access-controls/guides/moderated-sessions/#join_sessions
             JoinSession(
-                (User.traits["team"].contains("dev")) &
-                ((JoinSession.mode == "observer") | (JoinSession.mode == "peer")) &
-                ((Session.owner.traits["team"].contains("dev")) | (Session.owner.traits["team"].contains("intern")))
+                (User.traits["team"].contains("dev"))
+                & ((JoinSession.mode == "observer") | (JoinSession.mode == "peer"))
+                & (
+                    (Session.owner.traits["team"].contains("dev"))
+                    | (Session.owner.traits["team"].contains("intern"))
+                )
             ),
         ),
-        deny=Rules(
-            JoinSession(
-                User.traits["team"].contains("intern")
-            )
-        )
+        deny=Rules(JoinSession(User.traits["team"].contains("intern"))),
     )
 
     def test_access(self):
-        ret, _ = self.p.check(
+        ret = self.p.check(
             JoinSession(
-                (User.traits["team"] == ("dev",)) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev",))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is True, "a dev user can join a session from an intern user as an observer"
+        assert (
+            ret.solves is True
+        ), "a dev user can join a session from an intern user as an observer"
 
-        ret, _ = self.p.check(
+        ret = self.p.check(
             JoinSession(
-                (User.traits["team"] == ("marketing",)) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("marketing",))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a marketing user cannot join a session from an intern user as an observer"
+        assert (
+            ret.solves is False
+        ), "a marketing user cannot join a session from an intern user as an observer"
 
-        ret, _ = self.p.check(
+        ret = self.p.check(
             JoinSession(
-                (User.traits["team"] == ("dev",)) &
-                (JoinSession.mode == "moderator") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev",))
+                & (JoinSession.mode == "moderator")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a dev user cannot join a session from an intern user as a moderator"
+        assert (
+            ret.solves is False
+        ), "a dev user cannot join a session from an intern user as a moderator"
 
-        ret, _ = self.p.check(
+        ret = self.p.check(
             JoinSession(
-                (User.traits["team"] == ("dev", "intern")) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev", "intern"))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a dev intern user cannot join a session from an intern user as an observer"
+        assert (
+            ret.solves is False
+        ), "a dev intern user cannot join a session from an intern user as an observer"

--- a/predicate/mypy.ini
+++ b/predicate/mypy.ini
@@ -1,4 +1,3 @@
 [mypy]
 ignore_missing_imports = True
-exclude = examples
 

--- a/predicate/poetry.lock
+++ b/predicate/poetry.lock
@@ -10,7 +10,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "black"
@@ -46,11 +46,22 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.5"
+version = "0.4.6"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.4"
+description = "Backport of PEP 654 (exception groups)"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "flake8"
@@ -83,9 +94,9 @@ python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
-requirements_deprecated_finder = ["pip-api", "pipreqs"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "lint-python"
@@ -146,7 +157,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
-version = "0.10.1"
+version = "0.10.2"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "main"
 optional = false
@@ -154,15 +165,15 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.5.2"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "2.5.4"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
-test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.4)"]
+test = ["appdirs (==1.4.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -175,14 +186,6 @@ python-versions = ">=3.6"
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[[package]]
-name = "py"
-version = "1.11.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
@@ -213,7 +216,7 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
-version = "7.1.3"
+version = "7.2.0"
 description = "pytest: simple powerful testing with Python"
 category = "main"
 optional = false
@@ -222,17 +225,17 @@ python-versions = ">=3.7"
 [package.dependencies]
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-py = ">=1.8.2"
-tomli = ">=1.0.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
-name = "PyYAML"
+name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
@@ -241,7 +244,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "setuptools"
-version = "65.4.1"
+version = "65.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
@@ -249,7 +252,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -267,6 +270,33 @@ description = "A lil' TOML parser"
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.2"
+description = "Typing stubs for PyYAML"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-requests"
+version = "2.28.11.4"
+description = "Typing stubs for requests"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.4"
+description = "Typing stubs for urllib3"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
@@ -287,7 +317,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "3133493c42e82a69223f30162d4c726dbf3e0d02d32edae4fa0e0cf539b224e2"
+content-hash = "fe6585a5c18e50ae7324dd72d155959a4e5fa3e23cf310c15877b5745de22283"
 
 [metadata.files]
 attrs = [
@@ -322,8 +352,12 @@ click = [
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
-    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
-    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.0.4-py3-none-any.whl", hash = "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828"},
+    {file = "exceptiongroup-1.0.4.tar.gz", hash = "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"},
 ]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
@@ -380,20 +414,16 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
-    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
-    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+    {file = "pathspec-0.10.2-py3-none-any.whl", hash = "sha256:88c2606f2c1e818b978540f73ecc908e13999c6c3a383daf3705652ae79807a5"},
+    {file = "pathspec-0.10.2.tar.gz", hash = "sha256:8f6bf73e5758fd365ef5d58ce09ac7c27d2833a8d7da51712eac6e27e35141b0"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
-    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+    {file = "platformdirs-2.5.4-py3-none-any.whl", hash = "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"},
+    {file = "platformdirs-2.5.4.tar.gz", hash = "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
-]
-py = [
-    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
@@ -408,10 +438,10 @@ pyparsing = [
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pytest = [
-    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
-    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
+    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
 ]
-PyYAML = [
+pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
@@ -454,8 +484,8 @@ PyYAML = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 setuptools = [
-    {file = "setuptools-65.4.1-py3-none-any.whl", hash = "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012"},
-    {file = "setuptools-65.4.1.tar.gz", hash = "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"},
+    {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
+    {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
@@ -464,6 +494,18 @@ toml = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+types-pyyaml = [
+    {file = "types-PyYAML-6.0.12.2.tar.gz", hash = "sha256:6840819871c92deebe6a2067fb800c11b8a063632eb4e3e755914e7ab3604e83"},
+    {file = "types_PyYAML-6.0.12.2-py3-none-any.whl", hash = "sha256:1e94e80aafee07a7e798addb2a320e32956a373f376655128ae20637adb2655b"},
+]
+types-requests = [
+    {file = "types-requests-2.28.11.4.tar.gz", hash = "sha256:d4f342b0df432262e9e326d17638eeae96a5881e78e7a6aae46d33870d73952e"},
+    {file = "types_requests-2.28.11.4-py3-none-any.whl", hash = "sha256:bdb1f9811e53d0642c8347b09137363eb25e1a516819e190da187c29595a1df3"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.25.4.tar.gz", hash = "sha256:eec5556428eec862b1ac578fb69aab3877995a99ffec9e5a12cf7fbd0cc9daee"},
+    {file = "types_urllib3-1.26.25.4-py3-none-any.whl", hash = "sha256:ed6b9e8a8be488796f72306889a06a3fc3cb1aa99af02ab8afb50144d7317e49"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/predicate/pyproject.toml
+++ b/predicate/pyproject.toml
@@ -24,11 +24,12 @@ click = "^8.1.3"
 setuptools = "^65.3.0"
 PyYAML = "^6.0"
 mypy = "^0.982"
+types-requests = "^2.28.11.4"
+types-pyyaml = "^6.0.12.2"
 
 [tool.lint-python]
 lint-version = "2"
 source = "."
-extra-requirements = "types-requests"
 use-mypy = true
 
 [tool.isort]

--- a/predicate/solver/test/test_aws.py
+++ b/predicate/solver/test/test_aws.py
@@ -7,43 +7,43 @@ class TestAWS:
     def test_aws_allow_policy(self, mixed_statement_policy):
         p = Predicate(aws.policy(mixed_statement_policy))
 
-        ret, _ = p.check(
+        ret = p.check(
             Predicate(
                 (aws.Action.resource == "arn:aws:s3:::example_bucket")
                 & (aws.Action.action == "s3:ListBucket")
             )
         )
-        assert ret is True
+        assert ret.solves is True
 
     def test_aws_policy(self, s3_policy):
         p = Predicate(aws.policy(s3_policy))
 
         # get bucket location on any bucket works
-        ret, d = p.check(
+        ret = p.check(
             Predicate(
                 (aws.Action.resource == "arn:aws:s3:::example_bucket")
                 & (aws.Action.action == "s3:GetBucketLocation")
             )
         )
-        assert ret is True
+        assert ret.solves is True
 
         # listing bucket logs is not allowed
-        ret, d = p.check(
+        ret = p.check(
             Predicate(
                 (aws.Action.resource == "arn:aws:s3:::example_bucket/logs")
                 & (aws.Action.action == "s3:GetObject")
             )
         )
-        assert ret is False
+        assert ret.solves is False
 
         # can get a random doc from a bucket
-        ret, d = p.check(
+        ret = p.check(
             Predicate(
                 (aws.Action.resource == "arn:aws:s3:::carlossalazar/document")
                 & (aws.Action.action == "s3:GetObject")
             )
         )
-        assert ret is True
+        assert ret.solves is True
 
 
 @pytest.fixture

--- a/predicate/solver/test/test_teleport.py
+++ b/predicate/solver/test/test_teleport.py
@@ -11,18 +11,19 @@ from .. import (
     StringSetMap,
 )
 from ..teleport import (
-    LoginRule,
-    User,
-    Node,
     AccessNode,
+    JoinSession,
+    LoginRule,
+    Node,
     Options,
-    OptionsSet,
     Policy,
     PolicyMap,
     PolicySet,
+    RecordingMode,
     Rules,
-    JoinSession,
     Session,
+    SourceIp,
+    User,
     map_policies,
     try_login,
 )
@@ -33,45 +34,55 @@ class TestTeleport:
         p = Policy(
             name="test",
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
-        ret, _ = p.check(
+        ret = p.check(
             AccessNode(
                 (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
         )
-        assert ret is True, "check works on a superset"
+        assert ret.solves is True, "check works on a superset"
 
     def test_allow_policy_set(self):
         a = Policy(
             name="a",
             allow=Rules(
-                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
         b = Policy(
             name="b",
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "stage")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "stage")
+                ),
             ),
         )
 
         s = PolicySet([a, b])
-        ret, _ = s.check(
+        ret = s.check(
             AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod"))
         )
-        assert ret is True, "check works on a subset"
+        assert ret.solves is True, "check works on a subset"
 
-        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "stage")))
-        assert ret is True, "check works on a subset"
+        ret = s.check(
+            AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "stage"))
+        )
+        assert ret.solves is True, "check works on a subset"
 
-        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
-        assert ret is False, "rejects the merge"
+        ret = s.check(
+            AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod"))
+        )
+        assert ret.solves is False, "rejects the merge"
 
     def test_deny_policy_set(self):
         a = Policy(
@@ -87,65 +98,169 @@ class TestTeleport:
         b = Policy(
             name="b",
             deny=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
         s = PolicySet([a, b])
-        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
-        assert ret is False, "deny in a set overrides allow"
+        ret = s.check(
+            AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod"))
+        )
+        assert ret.solves is False, "deny in a set overrides allow"
 
-        ret, _ = s.check(
+        ret = s.check(
             AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod"))
         )
-        assert ret is True, "non-denied part of allow is OK"
+        assert ret.solves is True, "non-denied part of allow is OK"
 
-    def test_valid_options(self):
-        # check that only < inequalities are possible
-        _ = Options(Options.max_session_ttl < Duration.new(hours=3))
-        _ = Options(Duration.new(hours=3) > Options.max_session_ttl)
+    def test_empty_policy(self):
+        with pytest.raises(ParameterError, match="policy name cannot be empty"):
+            _ = Policy(name="")
 
-        with pytest.raises(Exception):
-            _ = Options(Options.max_session_ttl > Duration.new(hours=3))
-        with pytest.raises(Exception):
-            _ = Options(Duration.new(hours=3) < Options.max_session_ttl)
+        with pytest.raises(
+            ParameterError,
+            match="policy must contain either options, allow or deny rules",
+        ):
+            _ = Policy(name="a")
 
-        with pytest.raises(Exception):
-            _ = Options(Options.max_session_ttl == Duration.new(hours=3))
-        with pytest.raises(Exception):
-            _ = Options(Duration.new(hours=3) == Options.max_session_ttl)
+        with pytest.raises(
+            ParameterError,
+            match="policy must contain either options, allow or deny rules",
+        ):
+            _ = Policy(name="a", options=Options(), allow=Rules(), deny=Rules())
 
-        with pytest.raises(Exception):
-            _ = Options(Options.max_session_ttl != Duration.new(hours=3))
-        with pytest.raises(Exception):
-            _ = Options(Duration.new(hours=3) != Options.max_session_ttl)
+        # policy only with options is valid
+        _ = Policy(name="a", options=Options(max_session_ttl=Duration.new(hours=10)))
+
+        # policy only with allow rules is valid
+        _ = Policy(name="a", allow=Rules(AccessNode(AccessNode.login == "root")))
+
+        # policy only with deny rules is valid
+        _ = Policy(name="a", deny=Rules(AccessNode(AccessNode.login == "root")))
+
+    def test_empty_rules(self):
+        assert Rules().empty() is True, "empty rules are empty"
+        assert (
+            Rules(AccessNode(AccessNode.login == "root")).empty() is False
+        ), "non empty rules are non empty"
+
+    def test_empty_options(self):
+        assert Options().empty() is True, "empty options are empty"
+        assert (
+            Options(max_session_ttl=Duration.new(hours=10)).empty() is False
+        ), "non empty options are non empty"
+
+        assert Rules().empty() is True, "empty rules are empty"
+        assert (
+            Rules(AccessNode(AccessNode.login == "root")).empty() is False
+        ), "non empty rules are non empty"
+
+    def test_options_init(self):
+        # TODO add tests ensuring that users cannot set invalid option values
+        # for example, the next test should fail and doesn't
+        _ = Options(
+            max_session_ttl=Duration.new(hours=10),
+            recording_mode=Duration.new(hours=10),
+            source_ip=Node.labels["env"] == "prod",
+        )
+
+    def test_options_combine(self):
+        result = Options.combine(
+            Options(),
+            Options(),
+        )
+        assert result.max_session_ttl is None
+        assert result.source_ip is None
+        assert result.recording_mode is None
+
+        result = Options.combine(
+            Options(max_session_ttl=Duration.new(hours=10)),
+            Options(),
+        )
+        assert result.max_session_ttl == Duration.new(hours=10)
+        assert result.source_ip is None
+        assert result.recording_mode is None
+
+        result = Options.combine(
+            Options(),
+            Options(max_session_ttl=Duration.new(hours=3)),
+        )
+        assert result.max_session_ttl == Duration.new(hours=3)
+        assert result.source_ip is None
+        assert result.recording_mode is None
+
+        result = Options.combine(
+            Options(max_session_ttl=Duration.new(hours=10)),
+            Options(max_session_ttl=Duration.new(hours=3)),
+        )
+        assert result.max_session_ttl == Duration.new(hours=3)
+        assert result.source_ip is None
+        assert result.recording_mode is None
+
+        result = Options.combine(
+            Options(max_session_ttl=Duration.new(hours=3)),
+            Options(max_session_ttl=Duration.new(hours=10)),
+        )
+        assert result.max_session_ttl == Duration.new(hours=3)
+        assert result.source_ip is None
+        assert result.recording_mode is None
+
+        result = Options.combine(
+            Options(source_ip=SourceIp.PINNED),
+            Options(source_ip=SourceIp.UNPINNED),
+        )
+        assert result.max_session_ttl is None
+        assert result.source_ip == SourceIp.PINNED
+        assert result.recording_mode is None
+
+        result = Options.combine(
+            Options(source_ip=SourceIp.UNPINNED),
+            Options(source_ip=SourceIp.PINNED),
+        )
+        assert result.max_session_ttl is None
+        assert result.source_ip == SourceIp.PINNED
+        assert result.recording_mode is None
+
+        result = Options.combine(
+            Options(recording_mode=RecordingMode.BEST_EFFORT),
+            Options(recording_mode=RecordingMode.STRICT),
+        )
+        assert result.max_session_ttl is None
+        assert result.source_ip is None
+        assert result.recording_mode == RecordingMode.STRICT
+
+        result = Options.combine(
+            Options(recording_mode=RecordingMode.STRICT),
+            Options(recording_mode=RecordingMode.BEST_EFFORT),
+        )
+        assert result.max_session_ttl is None
+        assert result.source_ip is None
+        assert result.recording_mode == RecordingMode.STRICT
 
     def test_options(self):
         p = Policy(
             name="b",
-            options=OptionsSet(
-                Options(
-                    (Options.max_session_ttl < Duration.new(hours=10))
-                    & (Options.max_session_ttl < Duration.new(seconds=10)),
-                )
+            options=Options(
+                max_session_ttl=Duration.new(hours=10),
             ),
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
-        ret, _ = p.check(
+        ret = p.check(
             AccessNode(
                 (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
-            # Since we only have <, it's impossible to specify a `session_ttl` that would not be valid.
-            # This means that the predicate will always match the policy.
-            & Options(Options.max_session_ttl < Duration.new(hours=3))
         )
-
-        assert ret is True, "options and core predicate matches"
+        assert ret.solves is True, "options and core predicate matches"
+        assert ret.options.max_session_ttl == Duration.new(hours=10)
 
     def test_options_extra(self):
         """
@@ -153,225 +268,184 @@ class TestTeleport:
         """
         p = Policy(
             name="p",
-            options=OptionsSet(
-                Options(
-                    (Options.max_session_ttl < Duration.new(hours=10))
-                ),
-                Options(Options.pin_source_ip == True),
+            options=Options(
+                max_session_ttl=Duration.new(hours=10),
+                source_ip=SourceIp.PINNED,
             ),
             allow=Rules(
                 # unrelated rules are with comma, related rules are part of the predicate
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
-        ret, _ = p.check(
+        ret = p.check(
             AccessNode(
                 (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
-            & Options(
-                (Options.max_session_ttl < Duration.new(hours=3))
-                # TODO: `check` doesn't require that `pin_source_ip` is defined here, but should!?.
-                & (Options.pin_source_ip == True)
-            )
         )
 
-        assert ret is True, "options and core predicate matches"
-
-        ret, _ = p.check(
-            AccessNode(
-                (AccessNode.login == "root")
-                & (Node.labels["env"] == "prod")
-                & (Node.labels["os"] == "Linux")
-            )
-            & Options(
-                (Options.max_session_ttl < Duration.new(hours=3))
-                & (Options.pin_source_ip == False)
-            )
-        )
-        assert ret is False, "options fails restriction when contradiction is specified"
+        assert ret.solves is True
+        assert ret.options.max_session_ttl == Duration.new(hours=10)
+        assert ret.options.source_ip == SourceIp.PINNED
 
     def test_options_policy_set(self):
         a = Policy(
             name="a",
-            options=OptionsSet(
-                Options(
-                    (Options.max_session_ttl < Duration.new(hours=10))
-                ),
-                Options(Options.pin_source_ip == True),
+            options=Options(
+                max_session_ttl=Duration.new(hours=10),
+                source_ip=SourceIp.PINNED,
+                recording_mode=RecordingMode.BEST_EFFORT,
             ),
             allow=Rules(
-                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode(
+                    (AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")
+                )
             ),
         )
 
         b = Policy(
             name="b",
+            options=Options(
+                max_session_ttl=Duration.new(hours=3),
+                source_ip=SourceIp.UNPINNED,
+                recording_mode=RecordingMode.STRICT,
+            ),
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
         p = PolicySet([a, b])
 
-        ret, _ = p.check(
+        ret = p.check(
             AccessNode(
                 (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
-            & Options(
-                (Options.max_session_ttl < Duration.new(hours=3))
-                & (Options.pin_source_ip == True)
-            )
         )
 
-        assert ret is True, "options and core predicate matches"
-
-        ret, _ = p.check(
-            AccessNode(
-                (AccessNode.login == "root")
-                & (Node.labels["env"] == "prod")
-                & (Node.labels["os"] == "Linux")
-            )
-            & Options(
-                (Options.max_session_ttl < Duration.new(hours=3))
-                & (Options.pin_source_ip == False)
-            )
-        )
-
-        assert ret is False, "options fails restriction"
+        assert ret.solves is True, "options and core predicate matches"
+        assert ret.options.max_session_ttl == Duration.new(hours=3)
+        assert ret.options.source_ip == SourceIp.PINNED
+        assert ret.options.recording_mode == RecordingMode.STRICT
 
     def test_options_policy_set_enum(self):
         # policy a requires best effort
         a = Policy(
             name="a",
-            options=OptionsSet(
-                Options(
-                    (Options.recording_mode > "best_effort")
-                    | (Options.recording_mode == "best_effort")
-                ),
+            options=Options(
+                recording_mode=RecordingMode.BEST_EFFORT,
             ),
             allow=Rules(
-                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode(
+                    (AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")
+                ),
             ),
         )
 
         # policy b requires strict recording mode
         b = Policy(
             name="b",
-            options=OptionsSet(
-                Options(Options.recording_mode == "strict"),
+            options=Options(
+                recording_mode=RecordingMode.STRICT,
             ),
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
         p = PolicySet([a, b])
 
-        ret, _ = p.check(
+        ret = p.check(
             AccessNode(
                 (AccessNode.login == "root")
                 & (Node.labels["env"] == "prod")
                 & (Node.labels["os"] == "Linux")
             )
-            & Options(Options.recording_mode == "strict")
         )
 
-        assert ret is True, "options and core predicate matches"
+        assert ret.solves is True, "options and core predicate matches"
+        assert ret.options.recording_mode == RecordingMode.STRICT
 
-        ret, _ = p.check(
-            AccessNode(
-                (AccessNode.login == "root")
-                & (Node.labels["env"] == "prod")
-                & (Node.labels["os"] == "Linux")
-            )
-            & Options(Options.recording_mode == "best_effort")
-        )
-
-        assert (
-            ret is False
-        ), "options fails recording mode restriction from the policy b"
-
-        ret, _ = p.check(
+        ret = p.check(
             AccessNode(
                 (AccessNode.login == "ubuntu")
                 & (Node.labels["env"] == "stage")
                 & (Node.labels["os"] == "Linux")
             )
-            & Options(Options.recording_mode == "strict")
         )
 
-        assert ret is True, "options and core predicate matches"
-
-        ret, _ = p.check(
-            AccessNode(
-                (AccessNode.login == "ubuntu")
-                & (Node.labels["env"] == "stage")
-                & (Node.labels["os"] == "Linux")
-            )
-            & Options(Options.recording_mode == "best_effort")
-        )
-
-        assert (
-            ret is False
-        ), "strict is enforced for all modes of access across all policies in the set"
+        assert ret.solves is True, "options and core predicate matches"
+        assert ret.options.recording_mode == RecordingMode.STRICT
 
     def test_join_session(self):
         p = Policy(
             name="join_session",
             allow=Rules(
                 JoinSession(
-                    (User.traits["team"].contains("dev")) &
-                    ((JoinSession.mode == "observer") | (JoinSession.mode == "peer")) &
-                    ((Session.owner.traits["team"].contains("dev")) | (Session.owner.traits["team"].contains("intern")))
+                    (User.traits["team"].contains("dev"))
+                    & ((JoinSession.mode == "observer") | (JoinSession.mode == "peer"))
+                    & (
+                        (Session.owner.traits["team"].contains("dev"))
+                        | (Session.owner.traits["team"].contains("intern"))
+                    )
                 ),
             ),
-            deny=Rules(
-                JoinSession(
-                    User.traits["team"].contains("intern")
-                )
-            )
+            deny=Rules(JoinSession(User.traits["team"].contains("intern"))),
         )
 
-        ret, _ = p.check(
+        ret = p.check(
             JoinSession(
-                (User.traits["team"] == ("dev",)) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev",))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is True, "a dev user can join a session from an intern user as an observer"
+        assert (
+            ret.solves is True
+        ), "a dev user can join a session from an intern user as an observer"
 
-        ret, _ = p.check(
+        ret = p.check(
             JoinSession(
-                (User.traits["team"] == ("marketing",)) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("marketing",))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a marketing user cannot join a session from an intern user as an observer"
+        assert (
+            ret.solves is False
+        ), "a marketing user cannot join a session from an intern user as an observer"
 
-        ret, _ = p.check(
+        ret = p.check(
             JoinSession(
-                (User.traits["team"] == ("dev",)) &
-                (JoinSession.mode == "moderator") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev",))
+                & (JoinSession.mode == "moderator")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a dev user cannot join a session from an intern user as a moderator"
+        assert (
+            ret.solves is False
+        ), "a dev user cannot join a session from an intern user as a moderator"
 
-        ret, _ = p.check(
+        ret = p.check(
             JoinSession(
-                (User.traits["team"] == ("dev", "intern")) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev", "intern"))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a dev intern user cannot join a session from an intern user as an observer"
+        assert (
+            ret.solves is False
+        ), "a dev intern user cannot join a session from an intern user as an observer"
 
     def test_login_rules(self):
         """
@@ -388,23 +462,22 @@ class TestTeleport:
             (external["email"] == ("alice@wonderland.local",))
             & (traits["login"] == ("alice-wonderland.local",))
         )
-        ret, _ = p.solve()
-        assert ret is True, "transformation has been applied"
+        ret = p.solve()
+        assert ret.solves is True, "transformation has been applied"
 
     def test_policy_wrong_expr(self):
         """
         Test that policy mapping always returns the right value
         """
-        with pytest.raises(ParameterError) as exc:
+        with pytest.raises(ParameterError, match="should eval to string list"):
             PolicyMap(
                 Select(
                     # Default is necessary to specify default empty sequence or type
                     Default(StringLiteral("test")),
                 )
             )
-        assert "should eval to string list" in str(exc.value)
 
-        with pytest.raises(ParameterError) as exc:
+        with pytest.raises(ParameterError):
             external = StringSetMap("external")
             PolicyMap(
                 Select(
@@ -434,17 +507,17 @@ class TestTeleport:
             )
         )
 
-        ret, _ = Predicate(
+        ret = Predicate(
             (s == ("ext-test", "ext-prod"))
             & (external["groups"] == ("admin-test", "admin-prod"))
         ).solve()
-        assert ret is True, "match and replace works"
+        assert ret.solves is True, "match and replace works"
 
-        ret, _ = Predicate(
+        ret = Predicate(
             (s == ("dev-test", "dev-prod"))
             & (external["groups"] == ("dev-test", "dev-prod"))
         ).solve()
-        assert ret is True, "match and replace works default value"
+        assert ret.solves is True, "match and replace works default value"
 
     def test_full_cycle(self):
         external = StringSetMap("external")
@@ -460,8 +533,8 @@ class TestTeleport:
             (external["email"] == ("alice@wonderland.local",))
             & (traits["login"] == ("alice-wonderland.local",))
         )
-        ret, _ = p.solve()
-        assert ret is True, "match and replace works in login rules"
+        ret = p.solve()
+        assert ret.solves is True, "match and replace works in login rules"
 
         s = PolicyMap(
             Select(
@@ -474,26 +547,32 @@ class TestTeleport:
             )
         )
 
-        ret, _ = Predicate(
+        ret = Predicate(
             (s == ("ext-test", "ext-prod"))
             & (external["groups"] == ("admin-test", "admin-prod"))
         ).solve()
-        assert ret is True, "match and replace works in policy maps"
+        assert ret.solves is True, "match and replace works in policy maps"
 
-        ret, _ = Predicate(
+        ret = Predicate(
             (s == ("dev-test", "dev-prod"))
             & (external["groups"] == ("dev-test", "dev-prod"))
         ).solve()
-        assert ret is True, "match and replace works in policy maps (default value)"
+        assert (
+            ret.solves is True
+        ), "match and replace works in policy maps (default value)"
 
         # dev policy allows access to stage, and denies access to root
         dev = Policy(
             name="dev-stage",
             allow=Rules(
-                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode(
+                    (AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")
+                ),
             ),
             deny=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
@@ -501,8 +580,8 @@ class TestTeleport:
         # but requires strict recording mode
         ext = Policy(
             name="ext-stage",
-            options=OptionsSet(
-                Options(Options.recording_mode == "strict"),
+            options=Options(
+                recording_mode=RecordingMode.STRICT,
             ),
             allow=Rules(
                 AccessNode(
@@ -515,8 +594,10 @@ class TestTeleport:
         p = PolicySet([dev, ext])
 
         # make sure that policy set will never allow access to prod
-        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
-        assert ret is False
+        ret = p.check(
+            AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod"))
+        )
+        assert ret.solves is False
 
         policy_names = try_login(
             s,
@@ -528,13 +609,13 @@ class TestTeleport:
 
         # policy set will allow Alice to connect to prod if her
         # email is alice@wonderland.local
-        ret, _ = p.check(
+        ret = p.check(
             AccessNode(
                 (AccessNode.login == "alice-wonderland.local")
                 & (Node.labels["env"] == "prod")
             )
         )
-        assert ret is True
+        assert ret.solves is True
 
         # TODO: How to simplify testing and make it shorter?
         # TODO: How to connect policy mappings and

--- a/predicate/solver/test/test_teleport_access_requests.py
+++ b/predicate/solver/test/test_teleport_access_requests.py
@@ -31,52 +31,52 @@ class TestTeleportAccessRequests:
         )
 
         # Can devs request access to stage?
-        ret, _ = devs.query(
+        ret = devs.query(
             Request(
                 (RequestPolicy.names == ("access-stage",))
                 & (RequestPolicy.approvals["access-stage"].len() > 0)
             )
         )
-        assert ret is True, "Devs can request access to stage"
+        assert ret.solves is True, "Devs can request access to stage"
 
-        ret, _ = devs.query(
+        ret = devs.query(
             Request(
                 (RequestPolicy.names == ("access-prod",))
                 & (RequestPolicy.approvals["access-prod"].len() > 0)
             )
         )
-        assert ret is False, "Devs can't request access to prod"
+        assert ret.solves is False, "Devs can't request access to prod"
 
         # Can devs review access to prod?
-        ret, _ = devs.query(
+        ret = devs.query(
             Review(
                 RequestPolicy.names.contains(
                     "access-stage",
                 )
             )
         )
-        assert ret is True, "Devs can review other folks access to stage"
+        assert ret.solves is True, "Devs can review other folks access to stage"
 
         # Can user with these policies review a role?
-        ret, _ = devs.query(
+        ret = devs.query(
             Review(
                 RequestPolicy.names.contains(
                     "access-prod",
                 )
             )
         )
-        assert ret is False, "can't review role that is not listed in the policy"
+        assert ret.solves is False, "can't review role that is not listed in the policy"
 
         # TODO: how to bind to roles?
-        ret, _ = devs.query(
+        ret = devs.query(
             Request(
                 (RequestPolicy.names == ("access-stage",))
                 & (RequestPolicy.approvals["access-stage"] == ("alice", "bob"))
             )
         )
-        assert ret is True, "two folks have approved the request"
+        assert ret.solves is True, "two folks have approved the request"
 
-        ret, _ = devs.query(
+        ret = devs.query(
             Request(
                 (RequestPolicy.names == ("access-stage",))
                 & (RequestPolicy.approvals["access-stage"] == ("alice", "bob"))
@@ -84,7 +84,7 @@ class TestTeleportAccessRequests:
             )
         )
         assert (
-            ret is False
+            ret.solves is False
         ), "two folks have approved the request, but one person denied it"
 
     def test_access_requests_review_expression(self):
@@ -114,7 +114,7 @@ class TestTeleportAccessRequests:
         )
 
         request = RequestPolicy.names == ("access-stage",)
-        ret, _ = devs.query(
+        ret = devs.query(
             Request(
                 request
                 & (
@@ -123,10 +123,10 @@ class TestTeleportAccessRequests:
                 )
             )
         )
-        assert ret is True, "one person have approved the request"
+        assert ret.solves is True, "one person have approved the request"
 
         request = RequestPolicy.names == ("access-stage",)
-        ret, _ = devs.query(
+        ret = devs.query(
             Request(
                 request
                 & (
@@ -135,7 +135,7 @@ class TestTeleportAccessRequests:
                 ),
             )
         )
-        assert ret is False, "one person has denied the request"
+        assert ret.solves is False, "one person has denied the request"
 
     def test_access_requests_review_limits(self):
         """
@@ -165,7 +165,7 @@ class TestTeleportAccessRequests:
         )
 
         # Can devs review access to stage?
-        ret, _ = devs.check(
+        ret = devs.check(
             Review(
                 (RequestPolicy.names == ("access-stage",))
                 & (RequestPolicy.approvals["access-stage"].len() > 0)
@@ -173,10 +173,12 @@ class TestTeleportAccessRequests:
                 & (Node.labels["env"] == "sre")
             )
         )
-        assert ret is True, "Devs can request access to stage for nodes in their env"
+        assert (
+            ret.solves is True
+        ), "Devs can request access to stage for nodes in their env"
 
         # Can devs review access to stage?
-        ret, _ = devs.check(
+        ret = devs.check(
             Review(
                 (RequestPolicy.names == ("access-stage",))
                 & (RequestPolicy.approvals["access-stage"].len() > 0)
@@ -185,7 +187,7 @@ class TestTeleportAccessRequests:
             )
         )
         assert (
-            ret is False
+            ret.solves is False
         ), "Devs can't request access to stage for nodes not in their env"
 
     def test_access_requests_multi(self):
@@ -229,26 +231,26 @@ class TestTeleportAccessRequests:
         )
 
         # Can devs request access to stage?
-        ret, _ = devs.query(
+        ret = devs.query(
             Request(
                 (RequestPolicy.names.contains("access-stage"))
                 & (RequestPolicy.approvals["access-stage"].len() > 0)
             )
         )
-        assert ret is True, "Devs can request access to stage"
+        assert ret.solves is True, "Devs can request access to stage"
 
         # Can devs request access to stage and prod at the same time?
-        ret, _ = devs.query(
+        ret = devs.query(
             Request(
                 (RequestPolicy.names == ("access-stage", "access-prod"))
                 & (RequestPolicy.approvals["access-stage"].len() > 0)
             )
         )
-        assert ret is True, "Devs can request access to stage and prod"
+        assert ret.solves is True, "Devs can request access to stage and prod"
 
         # With multi-roles, both roles have to be requested
         request = RequestPolicy.names == ("access-stage",)
-        ret, _ = devs.check(
+        ret = devs.check(
             Request(
                 request
                 & (
@@ -258,11 +260,11 @@ class TestTeleportAccessRequests:
             )
         )
         assert (
-            ret is False
+            ret.solves is False
         ), "one person have approved the request, but the request fails because both roles have to be requested"
 
         # Request for two policies got approved
-        ret, model = devs.check(
+        ret = devs.check(
             Request(
                 (RequestPolicy.names == ("access-stage", "access-prod"))
                 & (
@@ -283,7 +285,7 @@ class TestTeleportAccessRequests:
             )
         )
         assert (
-            ret is True
+            ret.solves is True
         ), "request is approved with two approvals for prod and one for stage"
 
     def test_access_requests_todo(self):

--- a/predicate/solver/test/test_teleport_get_started.py
+++ b/predicate/solver/test/test_teleport_get_started.py
@@ -18,8 +18,8 @@ class TestTeleportGetStarted:
         )
 
         # Check if alice can access nodes as root
-        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (User.name == "alice")))
-        assert ret is True, "everyone can access as root, including alice"
+        ret = p.check(AccessNode((AccessNode.login == "root") & (User.name == "alice")))
+        assert ret.solves is True, "everyone can access as root, including alice"
 
         # This is not a very useful policy, because it gives everyone
         # access as root. Let's narrow down this policy to let users
@@ -32,16 +32,18 @@ class TestTeleportGetStarted:
         )
 
         # Alice will be able to login to any machine as herself
-        ret, _ = p.check(AccessNode((AccessNode.login == "alice") & (User.name == "alice")))
-        assert ret is True, "Alice can login with her user to any node"
+        ret = p.check(
+            AccessNode((AccessNode.login == "alice") & (User.name == "alice"))
+        )
+        assert ret.solves is True, "Alice can login with her user to any node"
 
         # We can verify that a strong invariant holds:
         # Unless a username is root, a user can not access a server as
         # root. This creates a problem though, can we deny access as root
         # altogether?
-        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (User.name != "root")))
+        ret = p.check(AccessNode((AccessNode.login == "root") & (User.name != "root")))
         assert (
-            ret is False
+            ret.solves is False
         ), "This role does not allow access as root unless a user name is root"
 
         # Let's prohibit root access altogether. Deny rules always take
@@ -58,8 +60,8 @@ class TestTeleportGetStarted:
         # partial conditions, our predicate requires user to be specified,
         # while this query does not specify any user. Checks require all
         # parameters of the predicate, while queries do not.
-        ret, _ = p.query(AccessNode((AccessNode.login == "root")))
-        assert ret is False, "This role does not allow access as root to anyone"
+        ret = p.query(AccessNode((AccessNode.login == "root")))
+        assert ret.solves is False, "This role does not allow access as root to anyone"
 
     def test_node_access_multiple_teams(self):
         """
@@ -82,7 +84,7 @@ class TestTeleportGetStarted:
         )
 
         # Check if alice can access nodes as root
-        ret, _ = devs_and_admins.check(
+        ret = devs_and_admins.check(
             AccessNode(
                 (User.name == "alice")
                 & (User.traits["team"] == ("dev",))
@@ -91,11 +93,11 @@ class TestTeleportGetStarted:
             )
         )
         assert (
-            ret is True
+            ret.solves is True
         ), "Policy lets Alice to access nodes as her username if nodes are labeled with dev"
 
         # Check if bob can access nodes as root
-        ret, _ = devs_and_admins.check(
+        ret = devs_and_admins.check(
             AccessNode(
                 (User.name == "bob")
                 & (User.traits["team"] == ("db-admins",))
@@ -104,7 +106,7 @@ class TestTeleportGetStarted:
             )
         )
         assert (
-            ret is True
+            ret.solves is True
         ), "Policy lets Bob to access nodes as her username if nodes are labeled with dev"
 
         # The policy


### PR DESCRIPTION
This PR is the first step towards #43.

It only focus on the following options for now:
- `max_session_ttl`
- `recording_mode`
- `source_ip`

The idea is to gather feedback on the general approach implemented here before implementing the remaining options.

#### From option inequalities to a simple struct

Before this PR, options were specified using inequalities. Instead now we have:

```python
    p = Policy(
        name="access",
        options=Options(
            max_session_ttl=Duration.new(hours=10),
            recording_mode=RecordingMode.STRICT,
            source_ip=SourceIp.PINNED,
        ),
        allow=Rules(
            AccessNode(
                (User.traits["team"] == ("admins",))
            ),
        ),
    )
```

With predictable option combining (#43) there's no need to say `max_session_ttl < 10h` to try to imply that the `min` will be chosen in case two of these are combined.

Combining two of these inequalities using logical `AND` also doesn't seem to make sense.
If we say `max_session_ttl < 10 AND max_session_ttl < 3`, this is equivalent to `max_session_ttl < 3`
When Z3 solves this (see the solver proposed in #27) it will output `max_session_ttl == 0` as that's a valid solution.

In general, saying `max_session_ttl < 3` could be interpreted as "`max_session_ttl` can have any value smaller than 3", but this is not exactly what we want it to mean.

#### Option combining

Option combining is implemented outside of Z3 as it's very easy to do so (e.g. just call `min`).

#### `export` output

As options are not defined using inequalities, the `export` command now outputs them as a list.

`predicate export examples/access.py` outputs the following:

```yaml
kind: policy
metadata:
  name: access
spec:
  allow:
    access_node: (((access_node.login == user.name) && (!(user.name == "root"))) ||
      equals(user.traits["team"], ["admins"]))
  deny:
    access_node: (((access_node.login == "mike") || (access_node.login == "jester"))
      || (node.labels["env"] == "prod"))
  options:
    max_session_ttl: 36000000000000
    recording_mode: strict
    source_ip: pinned
version: v1
```

#### Other changes

While working on this I made some general improvements:
- ran linter (fixed issues and formatted the code)
- added linter to CI (hit https://github.com/python/mypy/issues/10632, which took many iterations to solve)
- simplified the README so that it points to the `examples` folder and doesn't contain outdated information
- ran `poetry update` which updated `poetry.lock`
- removed some unused functions
- added types to some functions
- added a `TeleportSolverResult` that encapsulates the outcomes of the solver
- removed `LtDuration` as it's no longer needed
- simplified `build_predicate`
