### PR TITLE
Adds defaults to access requests using quantifiers.

### DIFF
--- a/predicate/examples/join_session.py
+++ b/predicate/examples/join_session.py
@@ -1,4 +1,4 @@
-from solver.teleport import JoinSession, Session, Policy, Rules, User, AccessNode
+from solver.teleport import AccessNode, JoinSession, Policy, Rules, Session, User
 
 
 class Teleport:
@@ -9,51 +9,58 @@ class Teleport:
             # Equivalent to `join_sessions`:
             # https://goteleport.com/docs/access-controls/guides/moderated-sessions/#join_sessions
             JoinSession(
-                (User.traits["team"].contains("dev")) &
-                ((JoinSession.mode == "observer") | (JoinSession.mode == "peer")) &
-                ((Session.owner.traits["team"].contains("dev")) | (Session.owner.traits["team"].contains("intern")))
+                (User.traits["team"].contains("dev"))
+                & ((JoinSession.mode == "observer") | (JoinSession.mode == "peer"))
+                & (
+                    (Session.owner.traits["team"].contains("dev"))
+                    | (Session.owner.traits["team"].contains("intern"))
+                )
             ),
         ),
-        deny=Rules(
-            JoinSession(
-                User.traits["team"].contains("intern")
-            )
-        )
+        deny=Rules(JoinSession(User.traits["team"].contains("intern"))),
     )
 
     def test_access(self):
         ret, _ = self.p.check(
             JoinSession(
-                (User.traits["team"] == ("dev",)) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev",))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is True, "a dev user can join a session from an intern user as an observer"
+        assert (
+            ret is True
+        ), "a dev user can join a session from an intern user as an observer"
 
         ret, _ = self.p.check(
             JoinSession(
-                (User.traits["team"] == ("marketing",)) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("marketing",))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a marketing user cannot join a session from an intern user as an observer"
+        assert (
+            ret is False
+        ), "a marketing user cannot join a session from an intern user as an observer"
 
         ret, _ = self.p.check(
             JoinSession(
-                (User.traits["team"] == ("dev",)) &
-                (JoinSession.mode == "moderator") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev",))
+                & (JoinSession.mode == "moderator")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a dev user cannot join a session from an intern user as a moderator"
+        assert (
+            ret is False
+        ), "a dev user cannot join a session from an intern user as a moderator"
 
         ret, _ = self.p.check(
             JoinSession(
-                (User.traits["team"] == ("dev", "intern")) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev", "intern"))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a dev intern user cannot join a session from an intern user as an observer"
+        assert (
+            ret is False
+        ), "a dev intern user cannot join a session from an intern user as an observer"

--- a/predicate/solver/test/test_ast.py
+++ b/predicate/solver/test/test_ast.py
@@ -716,9 +716,7 @@ class TestAst:
         e = StringEnum("fruits", set(["banana", "apple", "strawberry"]))
 
         # enums could be part of the predicate
-        p = Predicate(
-            (e == 'apple') | (e == 'banana')
-        )
+        p = Predicate((e == "apple") | (e == "banana"))
         ret, _ = p.query(Predicate(e == "banana"))
         assert ret is True, "value can be banana"
 

--- a/predicate/solver/test/test_teleport.py
+++ b/predicate/solver/test/test_teleport.py
@@ -11,18 +11,18 @@ from .. import (
     StringSetMap,
 )
 from ..teleport import (
-    LoginRule,
-    User,
-    Node,
     AccessNode,
+    JoinSession,
+    LoginRule,
+    Node,
     Options,
     OptionsSet,
     Policy,
     PolicyMap,
     PolicySet,
     Rules,
-    JoinSession,
     Session,
+    User,
     map_policies,
     try_login,
 )
@@ -33,7 +33,9 @@ class TestTeleport:
         p = Policy(
             name="test",
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
@@ -50,14 +52,18 @@ class TestTeleport:
         a = Policy(
             name="a",
             allow=Rules(
-                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "ubuntu") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
         b = Policy(
             name="b",
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "stage")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "stage")
+                ),
             ),
         )
 
@@ -67,10 +73,14 @@ class TestTeleport:
         )
         assert ret is True, "check works on a subset"
 
-        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "stage")))
+        ret, _ = s.check(
+            AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "stage"))
+        )
         assert ret is True, "check works on a subset"
 
-        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
+        ret, _ = s.check(
+            AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod"))
+        )
         assert ret is False, "rejects the merge"
 
     def test_deny_policy_set(self):
@@ -87,12 +97,16 @@ class TestTeleport:
         b = Policy(
             name="b",
             deny=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
         s = PolicySet([a, b])
-        ret, _ = s.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
+        ret, _ = s.check(
+            AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod"))
+        )
         assert ret is False, "deny in a set overrides allow"
 
         ret, _ = s.check(
@@ -130,7 +144,9 @@ class TestTeleport:
                 )
             ),
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
@@ -154,14 +170,14 @@ class TestTeleport:
         p = Policy(
             name="p",
             options=OptionsSet(
-                Options(
-                    (Options.max_session_ttl < Duration.new(hours=10))
-                ),
+                Options((Options.max_session_ttl < Duration.new(hours=10))),
                 Options(Options.pin_source_ip == True),
             ),
             allow=Rules(
                 # unrelated rules are with comma, related rules are part of the predicate
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
@@ -197,20 +213,22 @@ class TestTeleport:
         a = Policy(
             name="a",
             options=OptionsSet(
-                Options(
-                    (Options.max_session_ttl < Duration.new(hours=10))
-                ),
+                Options((Options.max_session_ttl < Duration.new(hours=10))),
                 Options(Options.pin_source_ip == True),
             ),
             allow=Rules(
-                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode(
+                    (AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")
+                ),
             ),
         )
 
         b = Policy(
             name="b",
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
@@ -255,7 +273,9 @@ class TestTeleport:
                 ),
             ),
             allow=Rules(
-                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode(
+                    (AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")
+                ),
             ),
         )
 
@@ -266,7 +286,9 @@ class TestTeleport:
                 Options(Options.recording_mode == "strict"),
             ),
             allow=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
@@ -325,53 +347,60 @@ class TestTeleport:
             name="join_session",
             allow=Rules(
                 JoinSession(
-                    (User.traits["team"].contains("dev")) &
-                    ((JoinSession.mode == "observer") | (JoinSession.mode == "peer")) &
-                    ((Session.owner.traits["team"].contains("dev")) | (Session.owner.traits["team"].contains("intern")))
+                    (User.traits["team"].contains("dev"))
+                    & ((JoinSession.mode == "observer") | (JoinSession.mode == "peer"))
+                    & (
+                        (Session.owner.traits["team"].contains("dev"))
+                        | (Session.owner.traits["team"].contains("intern"))
+                    )
                 ),
             ),
-            deny=Rules(
-                JoinSession(
-                    User.traits["team"].contains("intern")
-                )
-            )
+            deny=Rules(JoinSession(User.traits["team"].contains("intern"))),
         )
 
         ret, _ = p.check(
             JoinSession(
-                (User.traits["team"] == ("dev",)) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev",))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is True, "a dev user can join a session from an intern user as an observer"
+        assert (
+            ret is True
+        ), "a dev user can join a session from an intern user as an observer"
 
         ret, _ = p.check(
             JoinSession(
-                (User.traits["team"] == ("marketing",)) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("marketing",))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a marketing user cannot join a session from an intern user as an observer"
+        assert (
+            ret is False
+        ), "a marketing user cannot join a session from an intern user as an observer"
 
         ret, _ = p.check(
             JoinSession(
-                (User.traits["team"] == ("dev",)) &
-                (JoinSession.mode == "moderator") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev",))
+                & (JoinSession.mode == "moderator")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a dev user cannot join a session from an intern user as a moderator"
+        assert (
+            ret is False
+        ), "a dev user cannot join a session from an intern user as a moderator"
 
         ret, _ = p.check(
             JoinSession(
-                (User.traits["team"] == ("dev", "intern")) &
-                (JoinSession.mode == "observer") &
-                (Session.owner.traits["team"] == ("intern",))
+                (User.traits["team"] == ("dev", "intern"))
+                & (JoinSession.mode == "observer")
+                & (Session.owner.traits["team"] == ("intern",))
             )
         )
-        assert ret is False, "a dev intern user cannot join a session from an intern user as an observer"
+        assert (
+            ret is False
+        ), "a dev intern user cannot join a session from an intern user as an observer"
 
     def test_login_rules(self):
         """
@@ -490,10 +519,14 @@ class TestTeleport:
         dev = Policy(
             name="dev-stage",
             allow=Rules(
-                AccessNode((AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")),
+                AccessNode(
+                    (AccessNode.login == "ubuntu") & (Node.labels["env"] == "stage")
+                ),
             ),
             deny=Rules(
-                AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")),
+                AccessNode(
+                    (AccessNode.login == "root") & (Node.labels["env"] == "prod")
+                ),
             ),
         )
 
@@ -515,7 +548,9 @@ class TestTeleport:
         p = PolicySet([dev, ext])
 
         # make sure that policy set will never allow access to prod
-        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod")))
+        ret, _ = p.check(
+            AccessNode((AccessNode.login == "root") & (Node.labels["env"] == "prod"))
+        )
         assert ret is False
 
         policy_names = try_login(

--- a/predicate/solver/test/test_teleport_get_started.py
+++ b/predicate/solver/test/test_teleport_get_started.py
@@ -18,7 +18,9 @@ class TestTeleportGetStarted:
         )
 
         # Check if alice can access nodes as root
-        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (User.name == "alice")))
+        ret, _ = p.check(
+            AccessNode((AccessNode.login == "root") & (User.name == "alice"))
+        )
         assert ret is True, "everyone can access as root, including alice"
 
         # This is not a very useful policy, because it gives everyone
@@ -32,14 +34,18 @@ class TestTeleportGetStarted:
         )
 
         # Alice will be able to login to any machine as herself
-        ret, _ = p.check(AccessNode((AccessNode.login == "alice") & (User.name == "alice")))
+        ret, _ = p.check(
+            AccessNode((AccessNode.login == "alice") & (User.name == "alice"))
+        )
         assert ret is True, "Alice can login with her user to any node"
 
         # We can verify that a strong invariant holds:
         # Unless a username is root, a user can not access a server as
         # root. This creates a problem though, can we deny access as root
         # altogether?
-        ret, _ = p.check(AccessNode((AccessNode.login == "root") & (User.name != "root")))
+        ret, _ = p.check(
+            AccessNode((AccessNode.login == "root") & (User.name != "root"))
+        )
         assert (
             ret is False
         ), "This role does not allow access as root unless a user name is root"


### PR DESCRIPTION
Quantifiers are Z3 expressions for specifying generic expressions valid for sets of parameters.

For example, for all x, x > 0. Quantifiers can make Z3 very slow, so here we use them with care to introduce defaults for access requests approvals.