### PR TITLE
Adds defaults to access requests using join-like semantics.

### DIFF
--- a/predicate/cli/__main__.py
+++ b/predicate/cli/__main__.py
@@ -81,13 +81,13 @@ def test(policy_file):
 
 
 @main.command()
-@click.option('--policy', '-p', is_flag=True)
+@click.option("--policy", "-p", is_flag=True)
 def new(policy):
     """
     Create a new policy based on template
     """
     if policy:
-        value = click.prompt('Please enter a policy name', type=str)
+        value = click.prompt("Please enter a policy name", type=str)
         click.echo("creating policy...")
         # keeping "policies" as a default directory
         create_policy_file(value, "")

--- a/predicate/cli/policy_utils.py
+++ b/predicate/cli/policy_utils.py
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any
-from typing import Tuple
 from pathlib import Path
 from runpy import run_path
-from jinja2 import FileSystemLoader, Environment, select_autoescape
+from typing import Any, Tuple
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
 from solver.teleport import Policy
 
 
@@ -31,11 +32,10 @@ def get_policy(policy_file: str) -> Tuple[str, dict[str, Any]]:
     class_name = ""
     for key, value in module.items():
         # Grabs 'p' of Policy class
-        if hasattr(value, 'p') and isinstance(value.p, Policy):
+        if hasattr(value, "p") and isinstance(value.p, Policy):
             class_name = key
-    
-    return class_name, module[class_name].p
 
+    return class_name, module[class_name].p
 
 
 def create_policy_file(name: str, path: str):
@@ -53,7 +53,7 @@ def create_policy_file(name: str, path: str):
 
     # keeping "policies" as a default directory
     file_name = normalize_policy_name(name, "")
-    with open(f"{default_path}/{file_name}.py", 'w', encoding="utf-8") as file:
+    with open(f"{default_path}/{file_name}.py", "w", encoding="utf-8") as file:
         file.write(policy)
 
 
@@ -66,7 +66,7 @@ def create_policy_from_template(name: str):
     values = {
         "policyclass": class_name,
         "policyname": policy_name,
-        "testname": f"test_{policy_name}"
+        "testname": f"test_{policy_name}",
     }
 
     template_loader = FileSystemLoader(searchpath="./")

--- a/predicate/cli/tests/mock_policy.py
+++ b/predicate/cli/tests/mock_policy.py
@@ -1,11 +1,13 @@
 from solver.ast import Duration
 from solver.teleport import AccessNode, Node, Options, OptionsSet, Policy, Rules, User
 
+
 class Administrator:
     p = Rules(AccessNode((AccessNode.login == "dev")))
-    
+
     def test_administrator(self):
         pass
+
 
 class Developer:
     p = Policy(

--- a/predicate/cli/tests/test_policy_utils.py
+++ b/predicate/cli/tests/test_policy_utils.py
@@ -1,8 +1,14 @@
-from pathlib import Path
 import shutil
+from pathlib import Path
 
-from cli.policy_utils import create_policy_from_template, get_policy, normalize_policy_name, create_policy_file
+from cli.policy_utils import (
+    create_policy_file,
+    create_policy_from_template,
+    get_policy,
+    normalize_policy_name,
+)
 from solver.teleport import Policy, Rules
+
 
 def test_create_policy_file():
     policy_name = " test file_name-master Dev master "
@@ -18,7 +24,7 @@ def test_create_policy_file():
 def test_create_policy_from_template():
     """
     For policy name 'developer", the class name should be "Developer, name should be "developer"
-    and the test function should be "test_developer". 
+    and the test function should be "test_developer".
     """
     sample = """
 from solver.teleport import Policy, AccessNode, User, Rules
@@ -52,11 +58,12 @@ def test_get_policy():
     assert (class_name == "Developer") & isinstance(policy, Policy) is True
 
 
-
 def test_normalize_policy_name():
     name = " test policy_name-test"
 
     class_name = normalize_policy_name(name, "class")
     file_name = normalize_policy_name(name, "file")
 
-    assert (class_name == "TestPolicyNameTest") & (file_name == "test_policy_name_test") is True
+    assert (class_name == "TestPolicyNameTest") & (
+        file_name == "test_policy_name_test"
+    ) is True

--- a/predicate/experiments/join.py
+++ b/predicate/experiments/join.py
@@ -1,0 +1,17 @@
+import z3
+
+traits = z3.Function("traits", z3.StringSort(), z3.StringSort())
+x = z3.String("x")
+
+s = z3.Solver()
+s.add(traits(x) == z3.StringVal("potato"))
+s.add(traits(z3.StringVal("alice")) == z3.StringVal("potato"))
+s.add(x == z3.StringVal("alice"))
+print(s.check())
+
+
+s = z3.Solver()
+s.add(traits(x) == z3.StringVal("sre"))
+s.add(traits(z3.StringVal("alice")) == z3.StringVal("dev"))
+s.add(x == z3.StringVal("alice"))
+print(s.check())

--- a/predicate/solver/ast.py
+++ b/predicate/solver/ast.py
@@ -20,17 +20,22 @@ limitations under the License.
 # * book https://theory.stanford.edu/~nikolaj/programmingz3.html
 # * reference https://z3prover.github.io/api/html/namespacez3py.html
 
+
 import functools
 import operator
 import sre_constants
 import sre_parse
 import typing
+import uuid
 from collections.abc import Iterable
 from dataclasses import dataclass
 
 import z3
 
 from .errors import ParameterError
+
+# To add debugging verbose mode of Z3 itself, uncomment this line
+# z3.set_option(verbose=10)
 
 
 class LogicMixin:
@@ -503,10 +508,16 @@ class Duration(LtDuration):
     def __str__(self):
         return "duration({})".format(self.name)
 
-    def __eq__(self, val: DurationLiteral):
+    def __eq__(self, val: object):
+        # Python recommends to make eq generic
+        # https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+        if not isinstance(val, DurationLiteral):
+            return NotImplemented
         return Eq(self, val)
 
-    def __ne__(self, val: DurationLiteral):
+    def __ne__(self, val: object):
+        if not isinstance(val, DurationLiteral):
+            return NotImplemented
         return Not(Eq(self, val))
 
     def __gt__(self, val: DurationLiteral):
@@ -633,6 +644,12 @@ class StringList:
             self.fn_map = z3.RecFunction(self.name, z3.StringSort(), StringListSort)
             z3.RecAddDefinition(self.fn_map, [arg_key], iff(values))
 
+    def for_each(self, lambda_fn):
+        """
+        For each creates an expression that should hold true for each element
+        """
+        return StringListForEach(self, lambda_fn)
+
     def first(self):
         """
         First returns first non-empty value
@@ -684,6 +701,28 @@ class StringList:
         return self.fn_map(z3.StringVal(self.name))
 
 
+class StringListElement(String):
+    """
+    StringListElement is a proxy value that represents element
+    of the list in the for_each loop expressions
+    """
+
+    def __init__(self, string_list: StringList, element_expr=None):
+        String.__init__(self, string_list.name + "_string_list_element")
+        self.string_list = string_list
+        self.element_expr = element_expr
+
+    def walk(self, fn):
+        fn(self)
+        self.string_list.walk(fn)
+
+    def __str__(self):
+        return """({}.element())""".format(self.string_list)
+
+    def traverse(self):
+        return self.element_expr
+
+
 class StringListContains(LogicMixin):
     def __init__(self, expr: StringList, val):
         self.E = expr
@@ -701,6 +740,66 @@ class StringListContains(LogicMixin):
         return fn_string_list_contains(
             self.E.fn_map(z3.StringVal(self.E.name)), self.V.traverse()
         ) == z3.BoolVal(True)
+
+
+class StringListForEach(LogicMixin):
+    def __init__(self, string_list: StringList, for_each):
+        self.string_list = string_list
+        self.for_each = for_each
+
+    def walk(self, fn):
+        fn(self)
+        self.for_each(StringListElement(self.string_list)).walk(fn)
+
+    def __str__(self):
+        return """({}.for_each({}))""".format(
+            self.string_list, self.for_each(StringListElement(self.string_list))
+        )
+
+    def traverse(self):
+        uid = "string_list_for_each_{}".format(uuid.uuid4().hex)
+        fn_string_list_for_each = z3.RecFunction(uid, StringListSort, z3.BoolSort())
+
+        vals = z3.Const(uid + "_vals", StringListSort)
+
+        # We have generated an expression from lambda,
+        #
+        # and passed this expression into the recursive function definition
+        #
+        # Given the lambda function
+        #
+        # for_each(x: x == "potato"),
+        #
+        # We would get:
+        #
+        # StringListSort.car(vals) == z3.StringVal("potato")
+        #
+        # We pass this expression into recursive function definition below,
+        # and we call this anonymous recursive function on our list parameter.
+
+        # Each function defined here is unique, because each underlying lambda
+        # function spec is also unique.
+
+        z3.RecAddDefinition(
+            fn_string_list_for_each,
+            [vals],
+            z3.If(
+                StringListSort.nil == vals,
+                z3.BoolVal(True),
+                z3.If(
+                    z3.Not(
+                        self.for_each(
+                            StringListElement(
+                                self.string_list, StringListSort.car(vals)
+                            )
+                        ).traverse()
+                    ),
+                    z3.BoolVal(False),
+                    fn_string_list_for_each(StringListSort.cdr(vals)),
+                ),
+            ),
+        )
+        return fn_string_list_for_each(self.string_list.traverse())
 
 
 class StringListFirst:
@@ -1602,6 +1701,14 @@ class Select:
         return iterate(iter(self.cases))
 
 
+def deduplicate(seq):
+    """
+    Deduplicate preserves the order
+    """
+    seen = set()
+    return [x for x in seq if not (x in seen or seen.add(x))]
+
+
 class StringSetMap:
     """
     Map of string sets:
@@ -1620,8 +1727,8 @@ class StringSetMap:
             def iff(fn_key, iterator):
                 try:
                     key, val = next(iterator)
-                    if isinstance(val, tuple):
-                        val = StringTuple(val)
+                    if isinstance(val, (tuple, list)):
+                        val = StringTuple(deduplicate(val))
                 except StopIteration:
                     return StringListSort.nil
                 else:
@@ -1646,6 +1753,17 @@ class StringSetMap:
         # Map Index should impact function definition, aggregate it
         return StringSetMapIndex(self, key)
 
+    def __eq__(self, other):
+        if isinstance(other, StringSetMap):
+            return StringSetMapCompare(self, other, operator.eq)
+        return NotImplemented
+
+    def for_each_key(self):
+        """
+        For each key creates an expression that should hold true for each key.
+        """
+        return StringSetMapForEachKeyConstraint(self)
+
     def add_value(self, key: String, val: String):
         return StringSetMapAddValue(self, key, val)
 
@@ -1656,13 +1774,92 @@ class StringSetMap:
         return StringSetMapOverwrite(self, values)
 
     def __str__(self):
-        return """({} ^ {})""".format(self.L, self.R)
+        return """map({})""".format(self.name)
 
     def walk(self, fn):
         fn(self)
 
     def traverse(self):
         return self.fn_map
+
+
+class StringSetMapCompare(LogicMixin):
+    def __init__(self, a, b: StringSetMap, compare_operator):
+        self.a = a
+        self.b = b
+        self.compare_operator = compare_operator
+
+    def walk(self, fn):
+        fn(self)
+
+    def __str__(self):
+        return """({} {} {})""".format(self.a, self.b, self.compare_operator)
+
+    def traverse(self):
+        # Quantifiers
+        # https://microsoft.github.io/z3guide/docs/logic/Quantifiers/
+        arg_key = z3.String(self.a.name + "_eq")
+        return z3.ForAll(
+            [arg_key],
+            self.compare_operator(self.a.fn_map(arg_key), self.b.fn_map(arg_key)),
+            patterns=[self.a.fn_map(arg_key)],
+        )
+
+
+class StringSetMapForEachKeyConstraint(StringSetMap):
+    def __init__(self, m: StringSetMap):
+        self.m = m
+
+    def walk(self, fn):
+        fn(self)
+
+    def len(self):
+        return StringSetMapForEachKeyConstraintLen(self.m)
+
+    def __str__(self):
+        return """({}.for_each_key())""".format(self.m.name)
+
+
+class StringSetMapForEachKeyConstraintLen(StringSetMap):
+    def __init__(self, m: StringSetMap):
+        self.m = m
+
+    def walk(self, fn):
+        fn(self)
+
+    def __str__(self):
+        return """({}.for_each_key().len())""".format(self.m.name)
+
+    def __gt__(self, val):
+        if isinstance(val, int):
+            return Gt(self, IntLiteral(val))
+        if isinstance(val, (Int,)):
+            return Gt(self, val)
+        raise TypeError(
+            "unsupported type {}, supported integers only".format(type(val))
+        )
+
+    def __lt__(self, val):
+        if isinstance(val, int):
+            return Lt(self, IntLiteral(val))
+        if isinstance(val, (Int,)):
+            return Lt(self, val)
+        raise TypeError(
+            "unsupported type {}, supported integers only".format(type(val))
+        )
+
+    def compare(self, op, other):
+        # Quantifiers
+        # https://microsoft.github.io/z3guide/docs/logic/Quantifiers/
+        arg_key = z3.String(self.m.name + "_any_key")
+        return z3.ForAll(
+            [arg_key],
+            op(fn_string_list_len(self.m.fn_map(arg_key)), other),
+            patterns=[fn_string_list_len(self.m.fn_map(arg_key))],
+        )
+
+    def traverse(self):
+        raise ParameterError("should not be called")
 
 
 class StringSetMapOverwrite(StringSetMap):
@@ -1679,7 +1876,7 @@ class StringSetMapOverwrite(StringSetMap):
         def iff(fn_key, iterator, wrapped_map_fn):
             try:
                 key, val = next(iterator)
-                if isinstance(val, tuple):
+                if isinstance(val, (tuple, list)):
                     val = StringTuple(val)
             except StopIteration:
                 return wrapped_map_fn(fn_key)
@@ -1745,9 +1942,7 @@ class StringSetMapAddValue(StringSetMap):
 
     def walk(self, fn):
         fn(self)
-        self.E.walk(fn)
-        self.K.walk(fn)
-        self.V.walk(fn)
+        self.m.walk(fn)
 
     def __str__(self):
         return """({}.add({}, {}))""".format(self.m.name, self.K, self.V)
@@ -1814,6 +2009,9 @@ class StringSetMapIndex:
         self.m = m
         self.key = key
 
+    def parent(self):
+        return self.m
+
     def first(self):
         """
         First returns first non-empty value
@@ -1857,7 +2055,7 @@ class StringSetMapIndex:
         fn(self)
 
     def __eq__(self, val):
-        if isinstance(val, tuple):
+        if isinstance(val, (tuple, list)):
             return StringSetMapIndexEquals(self, StringTuple(val))
         return StringSetMapIndexEquals(self, val)
 
@@ -1879,24 +2077,42 @@ class StringSetMapIndexContains(LogicMixin):
         return """({}.contains({}))""".format(self.E, self.V)
 
     def traverse(self):
+        if hasattr(self.E.key, "traverse"):
+            key = self.E.key.traverse()
+            print(
+                "expr: {}".format(
+                    fn_string_list_contains(self.E.m.fn_map(key), self.V.traverse())
+                    == z3.BoolVal(True)
+                )
+            )
+        else:
+            key = z3.StringVal(self.E.key)
+
         return fn_string_list_contains(
-            self.E.m.fn_map(z3.StringVal(self.E.key)), self.V.traverse()
+            self.E.m.fn_map(key), self.V.traverse()
         ) == z3.BoolVal(True)
 
 
 class StringSetMapIndexLen(IntMixin):
     def __init__(self, expr: StringSetMapIndex):
-        self.E = expr
+        self.map_index = expr
 
     def walk(self, fn):
         fn(self)
-        self.E.walk(fn)
+        self.map_index.walk(fn)
+
+    def parent(self):
+        return self.map_index
 
     def __str__(self):
-        return """({}.len())""".format(self.E)
+        return """({}.len())""".format(self.map_index)
 
     def traverse(self):
-        return fn_string_list_len(self.E.m.fn_map(z3.StringVal(self.E.key)))
+        if hasattr(self.map_index.key, "traverse"):
+            key = self.map_index.key.traverse()
+        else:
+            key = z3.StringVal(self.map_index.key)
+        return fn_string_list_len(self.map_index.m.fn_map(key))
 
 
 class StringSetMapIndexFirst:
@@ -2081,7 +2297,6 @@ class Predicate:
         if self.loud:
             print("OUR EXPR: {}".format(e))
         solver.add(self.expr.traverse())
-
         if solver.check() == z3.unsat:
             raise ParameterError("our own predicate is unsolvable")
         return (True, solver.model())
@@ -2096,14 +2311,12 @@ class Predicate:
         if self.loud:
             print("OUR EXPR: {}".format(e))
         solver.add(e)
-
         if solver.check() == z3.unsat:
             raise ParameterError("our own predicate is unsolvable")
         o = other.expr.traverse()
         if self.loud:
             print("THEIR EXPR: {}".format(o))
         solver.add(o)
-
         # TODO do a second pass to build a key checking function
         # for both predicates!
         self.expr.walk(functools.partial(collect_symbols, self.symbols))

--- a/predicate/solver/test/test_teleport_access_requests.py
+++ b/predicate/solver/test/test_teleport_access_requests.py
@@ -1,4 +1,6 @@
-from ..ast import StringSetMap
+import pytest
+
+from ..ast import ParameterError, StringSetMap
 from ..teleport import Node, Policy, Request, RequestPolicy, Review, Rules, reviews
 
 
@@ -7,7 +9,7 @@ class TestTeleportAccessRequests:
     This test suite covers and explains access requests feature set.
     """
 
-    def test_access_requests(self):
+    def test_access_requests_single(self):
         """
         Access requests lets users to request access to resources - policies
         and nodes they don't have. Other team members review or deny access
@@ -16,14 +18,23 @@ class TestTeleportAccessRequests:
         """
         # Devs are allowed to request 'access-prod' policy.
         # Two approvals are required to proceed.
+        # Any denial invalidates the request.
         devs = Policy(
             name="devs",
             allow=Rules(
                 Request(
                     (
                         (RequestPolicy.names == ("access-stage",))
-                        & (RequestPolicy.approvals["access-stage"].len() > 1)
-                        & (RequestPolicy.denials["access-stage"].len() < 1)
+                        & (
+                            RequestPolicy.names.for_each(
+                                lambda x: RequestPolicy.approvals[x].len() > 1
+                            )
+                        )
+                        & (
+                            RequestPolicy.names.for_each(
+                                lambda x: RequestPolicy.denials[x].len() < 1
+                            )
+                        )
                     )
                 ),
                 Review(RequestPolicy.names == ("access-stage",)),
@@ -57,7 +68,7 @@ class TestTeleportAccessRequests:
         )
         assert ret is True, "Devs can review other folks access to stage"
 
-        # Can user with these policies review a role?
+        # Can user with these policies review a policy?
         ret, _ = devs.query(
             Review(
                 RequestPolicy.names.contains(
@@ -65,13 +76,16 @@ class TestTeleportAccessRequests:
                 )
             )
         )
-        assert ret is False, "can't review role that is not listed in the policy"
+        assert ret is False, "can't review policy that is not listed in the policy"
 
-        # TODO: how to bind to roles?
         ret, _ = devs.query(
             Request(
                 (RequestPolicy.names == ("access-stage",))
-                & (RequestPolicy.approvals["access-stage"] == ("alice", "bob"))
+                # Notice we are using full approval definition here using == to other map
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap("reviews", {"access-stage": ("alice", "bob")})
+                )
             )
         )
         assert ret is True, "two folks have approved the request"
@@ -79,15 +93,240 @@ class TestTeleportAccessRequests:
         ret, _ = devs.query(
             Request(
                 (RequestPolicy.names == ("access-stage",))
-                & (RequestPolicy.approvals["access-stage"] == ("alice", "bob"))
-                & (RequestPolicy.denials["access-stage"] == ("ketanji",))
+                # Notice we are using full approval definition here using == to other map
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap("reviews", {"access-stage": ("alice",)})
+                )
+            )
+        )
+        assert ret is False, "only one person has approved the request"
+
+        # TODO: it's easy to make a mistake and have the same name for StringSetMap
+        # * Create unique anonymous maps as a quick solution
+        # * Check for name collisions to avoid hard to debug bugs in the future.
+        ret, _ = devs.query(
+            Request(
+                (RequestPolicy.names == ("access-stage",))
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap("approvals", {"access-stage": ("alice", "bob")})
+                )
+                & (
+                    RequestPolicy.denials
+                    == StringSetMap("denials", {"access-stage": ("ketanji",)})
+                )
             )
         )
         assert (
             ret is False
         ), "two folks have approved the request, but one person denied it"
 
-    def test_access_requests_review_expression(self):
+    def test_access_requests_defaults(self):
+        """
+        Tests that at least one approval by default is required to proceed.
+        """
+        devs = Policy(
+            name="devs",
+            allow=Rules(
+                Request(RequestPolicy.names == ("access-stage",)),
+                Review(RequestPolicy.names == ("access-stage",)),
+            ),
+        )
+
+        request = RequestPolicy.names == ("access-stage",)
+
+        # First, verify that success is possible.
+        ret, _ = devs.query(
+            Request(
+                request
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap("approvals", {"access-stage": ("alice", "bob")})
+                )
+            )
+        )
+        assert ret is True, "request approved"
+
+        ret, _ = devs.query(
+            Request(
+                request
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap("approvals", {"access-stage": ()})
+                )
+            )
+        )
+        assert (
+            ret is False
+        ), "request is missing implicit minimum required approvers count"
+
+        ret, _ = devs.query(
+            Request(
+                request
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap("approvals", {"access-stage": ("bob", "ketanji")})
+                )
+                & (
+                    RequestPolicy.denials
+                    == StringSetMap("denials", {"access-stage": ("alice",)})
+                )
+            )
+        )
+        assert (
+            ret is False
+        ), "one person denied, access request is denied due to implicit deny default"
+
+        # the policy below has error in the sign that makes it unsolvable
+        devs = Policy(
+            name="devs",
+            allow=Rules(
+                Request(
+                    (
+                        (RequestPolicy.names == ("access-stage",))
+                        & (
+                            RequestPolicy.approvals["access-stage"].len() < 0
+                        )  # error in the sign
+                    )
+                ),
+                Review(RequestPolicy.names == ("access-stage",)),
+            ),
+        )
+
+        with pytest.raises(ParameterError) as exc:
+            request = RequestPolicy.names == ("access-stage",)
+            ret, _ = devs.query(
+                Request(
+                    request
+                    & (
+                        RequestPolicy.approvals
+                        == StringSetMap("approvals", {"access-stage": ()})
+                    )
+                )
+            )
+        assert "unsolvable" in str(exc.value)
+
+        # Test defaults with two policies
+        devs = Policy(
+            name="devs",
+            allow=Rules(
+                Request(
+                    (
+                        # When there are two policies in the list, both
+                        # have to pass their thresholds to be approved,
+                        # and any policy denied will result in denial for all
+                        (RequestPolicy.names == ("access-stage", "access-prod"))
+                    )
+                ),
+            ),
+        )
+
+        # First, make sure success is possible
+        request = RequestPolicy.names == ("access-stage", "access-prod")
+        ret, _ = devs.check(
+            Request(
+                request
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap(
+                        "approvals",
+                        {"access-stage": ("ketanji",), "access-prod": ("alice",)},
+                    )
+                )
+            )
+        )
+        assert ret is True, "Both polices have been approved"
+
+        request = RequestPolicy.names == ("access-stage", "access-prod")
+        ret, _ = devs.check(
+            Request(
+                request
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap(
+                        "approvals", {"access-stage": ("ketanji",), "access-prod": ()}
+                    )
+                )
+            )
+        )
+        assert (
+            ret is False
+        ), "one person have approved the request, but the request fails because both roles have to be approved"
+
+        request = RequestPolicy.names == ("access-stage", "access-prod")
+        ret, _ = devs.check(
+            Request(
+                request
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap(
+                        "approvals",
+                        {"access-stage": ("ketanji",), "access-prod": ("alice",)},
+                    )
+                )
+                & (
+                    RequestPolicy.denials
+                    == StringSetMap("denials", {"access-stage": ("bob",)})
+                )
+            )
+        )
+        assert (
+            ret is False
+        ), "Both polices have been approved, but one person denied one policy"
+
+    def test_access_requests_reviews_function(self):
+        """
+        Tests review function properties.
+        """
+        devs = Policy(
+            name="devs",
+            allow=Rules(
+                Review(RequestPolicy.names == ("access-stage",)),
+            ),
+        )
+
+        # Reviews needs request policy names to be concrete. It will eval RequestPolicy.names and for each one,
+        # will try to add a review
+        request = Request(RequestPolicy.names.contains("access-stage"))
+
+        assert reviews(
+            request,
+            ("alice", devs),  # alice reviewed as devs
+        ) == {"access-stage": ["alice"]}, "Simple review works"
+
+        request = Request(
+            RequestPolicy.names.contains("access-prod")
+            & RequestPolicy.names.contains("access-stage")
+        )
+        assert reviews(request, ("alice", devs),) == {
+            "access-stage": ["alice"],
+            "access-prod": [],
+        }, "Combined review works, but access-prod has no approvers"
+
+        # let's fix policy to allow both stage and prod review
+        devs = Policy(
+            name="devs",
+            allow=Rules(
+                Review(
+                    RequestPolicy.names.contains("access-stage")
+                    | RequestPolicy.names.contains("access-prod")
+                ),
+            ),
+        )
+        request = Request(
+            RequestPolicy.names
+            == (
+                "access-stage",
+                "access-prod",
+            )
+        )
+        assert reviews(request, ("alice", devs),) == {
+            "access-stage": ["alice"],
+            "access-prod": ["alice"],
+        }, "Combined review works"
+
+    def test_access_requests_reviews(self):
         """
         Model the approve / request scenario using review expression
         """
@@ -95,13 +334,7 @@ class TestTeleportAccessRequests:
         devs = Policy(
             name="devs",
             allow=Rules(
-                Request(
-                    (
-                        (RequestPolicy.names == ("access-stage",))
-                        & (RequestPolicy.approvals["access-stage"].len() > 0)
-                        & (RequestPolicy.denials["access-stage"].len() < 1)
-                    )
-                ),
+                Request(RequestPolicy.names == ("access-stage",)),
             ),
         )
 
@@ -118,20 +351,20 @@ class TestTeleportAccessRequests:
             Request(
                 request
                 & (
-                    RequestPolicy.approvals["access-stage"]
-                    == reviews((sre, Request(request)))
+                    RequestPolicy.approvals
+                    == StringSetMap("approvals", reviews(request, ("alice", sre)))
                 )
             )
         )
-        assert ret is True, "one person have approved the request"
+        assert ret is True, "one person has approved the request"
 
         request = RequestPolicy.names == ("access-stage",)
         ret, _ = devs.query(
             Request(
                 request
                 & (
-                    RequestPolicy.denials["access-stage"]
-                    == reviews((sre, Request(request)))
+                    RequestPolicy.denials
+                    == StringSetMap("approvals", reviews(request, ("ketanji", sre)))
                 ),
             )
         )
@@ -151,8 +384,11 @@ class TestTeleportAccessRequests:
                 Request(
                     (
                         (RequestPolicy.names == ("access-stage",))
-                        & (RequestPolicy.approvals["access-stage"].len() > 1)
-                        & (RequestPolicy.denials["access-stage"].len() < 1)
+                        & (
+                            RequestPolicy.names.for_each(
+                                lambda x: RequestPolicy.approvals[x].len() > 1
+                            )
+                        )
                     )
                 ),
                 Review(
@@ -206,24 +442,7 @@ class TestTeleportAccessRequests:
                         # have to pass their thresholds to be approved,
                         # and any policy denied will result in denial for all
                         (RequestPolicy.names == ("access-stage", "access-prod"))
-                        # At least one approval for stage
-                        & (RequestPolicy.approvals["access-stage"].len() > 0)
-                        & (RequestPolicy.denials["access-stage"].len() < 1)
-                        # At least two approvals for prod
-                        & (RequestPolicy.approvals["access-prod"].len() > 1)
-                        & (RequestPolicy.denials["access-prod"].len() < 1)
                     )
-                ),
-            ),
-        )
-
-        # allow reviewing access-stage or access-prod
-        sre = Policy(
-            name="sre",
-            allow=Rules(
-                Review(
-                    RequestPolicy.names.contains("access-stage")
-                    | RequestPolicy.names.contains("access-prod")
                 ),
             ),
         )
@@ -239,12 +458,25 @@ class TestTeleportAccessRequests:
 
         # Can devs request access to stage and prod at the same time?
         ret, _ = devs.query(
-            Request(
-                (RequestPolicy.names == ("access-stage", "access-prod"))
-                & (RequestPolicy.approvals["access-stage"].len() > 0)
-            )
+            Request((RequestPolicy.names == ("access-stage", "access-prod")))
         )
         assert ret is True, "Devs can request access to stage and prod"
+
+        # Test a successfull request
+        request = RequestPolicy.names == ("access-stage", "access-prod")
+        ret, _ = devs.check(
+            Request(
+                request
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap(
+                        "approvals",
+                        {"access-stage": ("ketanji",), "access-prod": ("alice",)},
+                    )
+                )
+            )
+        )
+        assert ret is True, "both policies have been requested and approved"
 
         # With multi-roles, both roles have to be requested
         request = RequestPolicy.names == ("access-stage",)
@@ -252,8 +484,11 @@ class TestTeleportAccessRequests:
             Request(
                 request
                 & (
-                    RequestPolicy.approvals["access-stage"]
-                    == reviews((sre, Request(request)))
+                    RequestPolicy.approvals
+                    == StringSetMap(
+                        "approvals",
+                        {"access-stage": ("ketanji",), "access-prod": ("alice",)},
+                    )
                 )
             )
         )
@@ -261,39 +496,83 @@ class TestTeleportAccessRequests:
             ret is False
         ), "one person have approved the request, but the request fails because both roles have to be requested"
 
-        # Request for two policies got approved
-        ret, model = devs.check(
+        request = RequestPolicy.names == ("access-stage", "access-prod")
+        ret, _ = devs.check(
             Request(
-                (RequestPolicy.names == ("access-stage", "access-prod"))
+                request
                 & (
-                    # two approvals for prod
-                    RequestPolicy.approvals["access-prod"]
-                    == reviews(
-                        (sre, Request(RequestPolicy.names.contains("access-prod"))),
-                        (sre, Request(RequestPolicy.names.contains("access-prod"))),
+                    RequestPolicy.approvals
+                    == StringSetMap(
+                        "approvals",
+                        {"access-stage": ("ketanji",), "access-prod": ("alice",)},
                     )
                 )
                 & (
-                    # one approval for staging
-                    RequestPolicy.approvals["access-stage"]
-                    == reviews(
-                        (sre, Request(RequestPolicy.names.contains("access-stage")))
-                    )
+                    RequestPolicy.denials
+                    == StringSetMap("denials", {"access-stage": ("bob",)})
                 )
             )
         )
         assert (
-            ret is True
-        ), "request is approved with two approvals for prod and one for stage"
+            ret is False
+        ), "both policies have been requested and approved, but one person has denied the request"
+
+    def test_access_requests_duplicates(self):
+        """
+        Makes sure that duplicate reviews are ignored
+        """
+        # Devs are allowed to request 'access-prod' policy.
+        # Two approvals are required to proceed.
+        # Any denial invalidates the request.
+        devs = Policy(
+            name="devs",
+            allow=Rules(
+                Request(
+                    (
+                        (RequestPolicy.names == ("access-stage",))
+                        # Need at least two denials to deny this access request
+                        & (
+                            RequestPolicy.names.for_each(
+                                lambda x: RequestPolicy.approvals[x].len() > 1
+                            )
+                        )
+                    )
+                ),
+                Review(RequestPolicy.names == ("access-stage",)),
+            ),
+        )
+        # Can devs request access to stage?
+        ret, _ = devs.query(
+            Request(
+                (RequestPolicy.names == ("access-stage",))
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap("approvals", {"access-stage": ("ketanji", "alice")})
+                )
+            )
+        )
+        assert ret is True, "Two approvals, from different people"
+
+        # Can devs request access to stage?
+        ret, _ = devs.query(
+            Request(
+                (RequestPolicy.names == ("access-stage",))
+                & (
+                    RequestPolicy.approvals
+                    == StringSetMap(
+                        "approvals", {"access-stage": ("ketanji", "ketanji")}
+                    )
+                )
+            )
+        )
+        assert ret is False, "Two approvals, but from the same person"
 
     def test_access_requests_todo(self):
         """
-        * More tests with access request failures?
-        * How to model search_as access requests properly?
-        * How to test that users cant review own requests.
-        * Static role can't be escaped - if you got role "a" and got role "b"
-        approved, you get both "a" and "b" in policy set
-        * The access requests syntax is a bit clumsy
-        * What happens if you miss thresholds?
-        * Implement permission boundaries (AWS-style)
+        * Model search_as access requests and resource based access requests.
+        * Add invariant that users cant review their own requests. To do that add a default that User.name != "self"?
+        * Model invariant that a static policy can't be escaped -
+        if you got policy "a" and got policy "b" approved, you get both "a" and "b" in policy set
+        * Model reviews where reviewer is authorized and reviews
+        just a part of access request (partial approval)
         """


### PR DESCRIPTION
Consider this problem. Users can request policies, and for each policy, there has to be at least one approver.

To express this in Z3, we introduce "for_each" expression:

```python
(RequestPolicy.names == ("access-stage",))
 & (
 RequestPolicy.names.for_each(
   lambda x: RequestPolicy.approvals[x].len() > 1))
```

This will get converted into anonymous recursive Z3 function that will iterate over list and apply the lambda expression.